### PR TITLE
fix: Correct SelectChangeEvent import in AssetForm

### DIFF
--- a/itsm_frontend/src/modules/assets/components/AssetForm.tsx
+++ b/itsm_frontend/src/modules/assets/components/AssetForm.tsx
@@ -10,8 +10,11 @@ import {
   Alert,
   Grid,
   Paper,
-  SelectChangeEvent, // For Select onChange
+  FormControl, // Added
+  InputLabel, // Added
+  // SelectChangeEvent removed from here
 } from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select'; // Corrected import
 
 import { useAuth } from '../../../context/auth/useAuth';
 import { useUI } from '../../../context/UIContext/useUI';


### PR DESCRIPTION
The type `SelectChangeEvent` was being imported from the main `@mui/material` package, which caused a SyntaxError at runtime because it's not directly exported from there in some Vite/MUI configurations.

This commit changes the import to:
`import type { SelectChangeEvent } from '@mui/material/Select';` which is the correct way to import this type.

This resolves the "does not provide an export named 'SelectChangeEvent'" error.