### PR TITLE
fix: Address procurement permissions, API types, and linting issues

### DIFF
--- a/itsm_frontend/src/api/assetApi.ts
+++ b/itsm_frontend/src/api/assetApi.ts
@@ -89,7 +89,7 @@ export interface GetListParams {
 }
 
 export interface GetAssetsParams extends GetListParams {
-  filters?: Record<string, string | number>; // e.g., { status: "in_use", category_id: 1 }
+  filters?: Record<string, string | number | boolean>; // Refined to include boolean for filter values
   sortBy?: string; // e.g., "name", "asset_tag"
   sortOrder?: 'asc' | 'desc'; // Default to 'asc' if not provided
 }

--- a/itsm_frontend/src/api/authApi.ts
+++ b/itsm_frontend/src/api/authApi.ts
@@ -22,7 +22,7 @@ export const loginApi = async (
   password: string,
 ): Promise<{
   token: string;
-  user: { name: string; role: string; id: number };
+  user: { name: string; role: string; id: number; is_staff: boolean }; // Added is_staff
 }> => {
   try {
     // This first call is PUBLIC (no token), so we use the native fetch API.
@@ -41,10 +41,12 @@ export const loginApi = async (
     const token: string = data.access;
 
     // Now that we have a token, we can use our new apiClient for the authenticated call.
-    const loggedInUser: { id: number; name: string; role: string } = {
+    // Update the type of loggedInUser to include is_staff
+    const loggedInUser: { id: number; name: string; role: string; is_staff: boolean } = {
       id: 0,
       name: username,
-      role: 'user', // Default role
+      role: 'user', // Default role, will be updated based on is_staff
+      is_staff: false, // Default is_staff
     };
 
     try {
@@ -62,9 +64,11 @@ export const loginApi = async (
           currentUser.first_name && currentUser.last_name
             ? `${currentUser.first_name} ${currentUser.last_name}`
             : currentUser.username;
+        loggedInUser.is_staff = currentUser.is_staff; // Store is_staff status
+        loggedInUser.role = currentUser.is_staff ? 'admin' : 'user'; // Update role based on is_staff
       } else {
         console.warn(
-          `loginApi: Could not find user details for username: ${username}.`,
+          `loginApi: Could not find user details for username: ${username}. Defaulting role to 'user' and is_staff to false.`,
         );
       }
     } catch (userFetchError) {

--- a/itsm_frontend/src/context/auth/AuthContextDefinition.ts
+++ b/itsm_frontend/src/context/auth/AuthContextDefinition.ts
@@ -6,6 +6,7 @@ export interface AuthUser {
   id: number;
   name: string; // Typically username or full name for display
   role: string; // User's role (e.g., 'user', 'admin')
+  is_staff: boolean; // Added to reflect staff status from backend
 }
 
 // Defines the shape of the authentication context itself.

--- a/itsm_frontend/src/modules/assets/AssetsPage.tsx
+++ b/itsm_frontend/src/modules/assets/AssetsPage.tsx
@@ -41,7 +41,7 @@ function a11yProps(index: number) {
 const AssetsPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<number>(0);
 
-  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => { // event changed to _event
     setActiveTab(newValue);
   };
 

--- a/itsm_frontend/src/modules/procurement/components/PurchaseRequestMemoList.tsx
+++ b/itsm_frontend/src/modules/procurement/components/PurchaseRequestMemoList.tsx
@@ -25,7 +25,7 @@ import {
   TextField,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-import EditIcon from '@mui/icons-material/Edit'; // Or VisibilityIcon for view
+// import EditIcon from '@mui/icons-material/Edit'; // Or VisibilityIcon for view - EditIcon is unused
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import CancelIcon from '@mui/icons-material/CancelOutlined';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
@@ -272,15 +272,15 @@ const PurchaseRequestMemoList: React.FC = () => {
                       <VisibilityIcon />
                     </IconButton>
                   </Tooltip>
-                  {memo.status === 'pending' && (user?.id === memo.requested_by || user?.is_staff) && (
+                  {memo.status === 'pending' && (user?.id === memo.requested_by || !!user?.is_staff) && (
                     <Tooltip title="Cancel Request">
                       <IconButton onClick={() => handleOpenCancelDialog(memo)} size="small" color="warning">
                         <CancelIcon />
                       </IconButton>
                     </Tooltip>
                   )}
-                  {/* Example: Show approve/reject only for staff/admin and if pending */}
-                  {memo.status === 'pending' && (user?.is_staff || user?.is_superuser) && (
+                  {/* Show approve/reject only for staff and if pending */}
+                  {memo.status === 'pending' && !!user?.is_staff && (
                     <>
                       <Tooltip title="Approve Request">
                         <IconButton onClick={() => handleOpenDecisionDialog(memo, 'approved')} size="small" color="success">


### PR DESCRIPTION
This commit includes several fixes and enhancements based on your feedback:

1.  **Procurement Permissions (`PurchaseRequestMemoList.tsx`)**:
    *   Updated the `AuthUser` type in `AuthContextDefinition.ts` to include `is_staff: boolean;`.
    *   Modified `loginApi` in `authApi.ts` to fetch and store the `is_staff` status from the backend user details and to derive `role` ('admin' or 'user') based on `is_staff`.
    *   Updated permission checks in `PurchaseRequestMemoList.tsx` for actions like 'Cancel', 'Approve', 'Reject' to use the `user.is_staff` property, resolving errors related to missing `is_superuser`.

2.  **API Parameter Typing (`assetApi.ts`)**:
    *   Refined the `filters` property in `GetAssetsParams` to `Record<string, string | number | boolean>` for better type specificity than a generic `any` or just `string | number`.

3.  **Unused Variable/Parameter Fixes**:
    *   Removed the unused `EditIcon` import from `PurchaseRequestMemoList.tsx`.
    *   Prefixed the unused `event` parameter in `AssetsPage.tsx`'s `handleTabChange` function with an underscore.

4.  **Conditional Logic (`NewServiceRequestPage.tsx`)**:
    *   Re-verified and confirmed that the conditional logic for `authenticatedFetch` within `fetchInitialData` and its calling `useEffect` is correctly structured to avoid "condition will always return true/false" warnings.

These changes improve permission handling in the new procurement module, enhance type safety in API definitions, and resolve various linting warnings.