### PR TITLE
fix: Correct migration dependency for procurement app

### DIFF
--- a/procurement/migrations/0002_purchaseorder_orderitem.py
+++ b/procurement/migrations/0002_purchaseorder_orderitem.py
@@ -9,7 +9,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('assets', '0002_assetcategory_location_vendor_alter_asset_category_and_more'),
+        ('assets', '0001_initial'), # Changed from 0002_...
         ('procurement', '0001_initial'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]


### PR DESCRIPTION
Resolves a `django.db.migrations.exceptions.NodeNotFoundError` that occurred because the `procurement.0002_purchaseorder_orderitem` migration referenced a non-existent parent node in the `assets` app (`assets.0002_assetcategory_location_vendor_alter_asset_category_and_more`).

The dependency in `procurement/migrations/0002_purchaseorder_orderitem.py` has been changed to point to `('assets', '0001_initial')`. This assumes that the `Vendor` model (from `assets.models`), which `PurchaseOrder` depends on, is available following the `assets` app's initial migration.

This change should allow the Django server to start and migrations to be applied correctly.