### PR TITLE
fix: Correct imports and cleanup types in PurchaseOrderForm

### DIFF
--- a/itsm_frontend/src/modules/procurement/components/PurchaseOrderForm.tsx
+++ b/itsm_frontend/src/modules/procurement/components/PurchaseOrderForm.tsx
@@ -19,6 +19,9 @@ import {
   TableRow,
   InputAdornment,
   Autocomplete,
+  FormControl, // Added
+  InputLabel,  // Added
+  Select,      // Added
 } from '@mui/material';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
@@ -42,7 +45,7 @@ import type {
   PurchaseRequestMemo, // For IOM selection
   // Vendor, // Removed from here
   PurchaseOrderStatus,
-  PaginatedResponse, // This might be unused if only results are directly used
+  // PaginatedResponse, // Removed as it's not directly used for annotations in this file
   VendorSummary, // This is available from procurementApi for vendor_details in PurchaseOrder
 } from '../../../api/procurementApi';
 


### PR DESCRIPTION
This commit addresses issues in `PurchaseOrderForm.tsx` based on your feedback:

1.  **MUI Component Imports**:
    *   Ensured that `FormControl`, `InputLabel`, and `Select` (used for the Status field refactor) are correctly and explicitly imported from `@mui/material`. This resolves "Cannot find name" runtime errors.

2.  **Unused Type Cleanup**:
    *   Removed the `PaginatedResponse` type import as it was not explicitly used for type annotations within the component.
    *   The `VendorSummary` type import was retained as it's used within other types (e.g., `PurchaseOrder` type for `displayHeaderData` state).
    *   The `currentTotalAmount` variable was confirmed to be used for display in JSX and was retained.

These changes improve the stability and correctness of `PurchaseOrderForm.tsx`.