### PR TITLE
refactor: Change AuthenticatedFetch return to Promise<unknown> for ty…

### DIFF
--- a/itsm_frontend/src/api/assetApi.ts
+++ b/itsm_frontend/src/api/assetApi.ts
@@ -4,7 +4,7 @@
 type AuthenticatedFetch = (
   endpoint: string,
   options?: RequestInit,
-) => Promise<any>;
+) => Promise<unknown>; // Changed Promise<any> to Promise<unknown>
 
 // --- Common Types ---
 export interface PaginatedResponse<T> {
@@ -107,7 +107,7 @@ export const getAssetCategories = async (
   if (params?.pageSize) queryParams.append('page_size', params.pageSize.toString()); // Standard DRF page size param
 
   const endpoint = `${API_BASE_PATH}/categories/${queryParams.toString() ? '?' : ''}${queryParams.toString()}`;
-  return await authenticatedFetch(endpoint, { method: 'GET' });
+  return await authenticatedFetch(endpoint, { method: 'GET' }) as PaginatedResponse<AssetCategory>;
 };
 
 export const createAssetCategory = async (
@@ -154,7 +154,7 @@ export const getLocations = async (
   if (params?.pageSize) queryParams.append('page_size', params.pageSize.toString());
 
   const endpoint = `${API_BASE_PATH}/locations/${queryParams.toString() ? '?' : ''}${queryParams.toString()}`;
-  return await authenticatedFetch(endpoint, { method: 'GET' });
+  return await authenticatedFetch(endpoint, { method: 'GET' }) as PaginatedResponse<Location>;
 };
 
 export const createLocation = async (
@@ -201,7 +201,7 @@ export const getVendors = async (
   if (params?.pageSize) queryParams.append('page_size', params.pageSize.toString());
 
   const endpoint = `${API_BASE_PATH}/vendors/${queryParams.toString() ? '?' : ''}${queryParams.toString()}`;
-  return await authenticatedFetch(endpoint, { method: 'GET' });
+  return await authenticatedFetch(endpoint, { method: 'GET' }) as PaginatedResponse<Vendor>;
 };
 
 export const createVendor = async (
@@ -258,7 +258,7 @@ export const getAssets = async (
   }
 
   const endpoint = `${API_BASE_PATH}/assets/${queryParams.toString() ? '?' : ''}${queryParams.toString()}`;
-  return await authenticatedFetch(endpoint, { method: 'GET' });
+  return await authenticatedFetch(endpoint, { method: 'GET' }) as PaginatedResponse<Asset>;
 };
 
 export const getAssetById = async (
@@ -266,7 +266,7 @@ export const getAssetById = async (
   id: number,
 ): Promise<Asset> => {
   const endpoint = `${API_BASE_PATH}/assets/${id}/`;
-  return await authenticatedFetch(endpoint, { method: 'GET' });
+  return await authenticatedFetch(endpoint, { method: 'GET' }) as Asset;
 };
 
 export const createAsset = async (

--- a/itsm_frontend/src/api/authApi.ts
+++ b/itsm_frontend/src/api/authApi.ts
@@ -86,7 +86,7 @@ export const loginApi = async (
 };
 
 export const getUserList = async (
-  authenticatedFetch: (endpoint: string, options?: RequestInit) => Promise<any>,
+  authenticatedFetch: (endpoint: string, options?: RequestInit) => Promise<unknown>, // Changed Promise<any> to Promise<unknown>
 ): Promise<User[]> => {
   // Token check is now handled by authenticatedFetch
   try {

--- a/itsm_frontend/src/api/procurementApi.ts
+++ b/itsm_frontend/src/api/procurementApi.ts
@@ -4,7 +4,7 @@
 export type AuthenticatedFetch = (
   endpoint: string,
   options?: RequestInit,
-) => Promise<any>;
+) => Promise<unknown>; // Changed Promise<any> to Promise<unknown>
 
 // 2. TypeScript Types/Interfaces
 
@@ -171,7 +171,7 @@ export const getPurchaseRequestMemos = async (
     });
   }
   const endpoint = `${API_PROCUREMENT_PATH}/memos/${queryParams.toString() ? '?' : ''}${queryParams.toString()}`;
-  return await authenticatedFetch(endpoint, { method: 'GET' });
+  return await authenticatedFetch(endpoint, { method: 'GET' }) as PaginatedResponse<PurchaseRequestMemo>;
 };
 
 export const createPurchaseRequestMemo = async (
@@ -183,7 +183,7 @@ export const createPurchaseRequestMemo = async (
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
-  });
+  }) as PurchaseRequestMemo;
 };
 
 export const getPurchaseRequestMemoById = async (
@@ -191,7 +191,7 @@ export const getPurchaseRequestMemoById = async (
   id: number,
 ): Promise<PurchaseRequestMemo> => {
   const endpoint = `${API_PROCUREMENT_PATH}/memos/${id}/`;
-  return await authenticatedFetch(endpoint, { method: 'GET' });
+  return await authenticatedFetch(endpoint, { method: 'GET' }) as PurchaseRequestMemo;
 };
 
 export const updatePurchaseRequestMemo = async (
@@ -204,7 +204,7 @@ export const updatePurchaseRequestMemo = async (
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
-  });
+  }) as PurchaseRequestMemo;
 };
 
 export const decidePurchaseRequestMemo = async (
@@ -217,7 +217,7 @@ export const decidePurchaseRequestMemo = async (
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(decisionData),
-  });
+  }) as PurchaseRequestMemo;
 };
 
 export const cancelPurchaseRequestMemo = async (
@@ -228,7 +228,7 @@ export const cancelPurchaseRequestMemo = async (
   return await authenticatedFetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-  });
+  }) as PurchaseRequestMemo;
 };
 
 
@@ -254,7 +254,7 @@ export const getPurchaseOrders = async (
     });
   }
   const endpoint = `${API_PROCUREMENT_PATH}/purchase-orders/${queryParams.toString() ? '?' : ''}${queryParams.toString()}`;
-  return await authenticatedFetch(endpoint, { method: 'GET' });
+  return await authenticatedFetch(endpoint, { method: 'GET' }) as PaginatedResponse<PurchaseOrder>;
 };
 
 export const createPurchaseOrder = async (
@@ -266,7 +266,7 @@ export const createPurchaseOrder = async (
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
-  });
+  }) as PurchaseOrder;
 };
 
 export const getPurchaseOrderById = async (
@@ -274,7 +274,7 @@ export const getPurchaseOrderById = async (
   id: number,
 ): Promise<PurchaseOrder> => {
   const endpoint = `${API_PROCUREMENT_PATH}/purchase-orders/${id}/`;
-  return await authenticatedFetch(endpoint, { method: 'GET' });
+  return await authenticatedFetch(endpoint, { method: 'GET' }) as PurchaseOrder;
 };
 
 export const updatePurchaseOrder = async (
@@ -287,7 +287,7 @@ export const updatePurchaseOrder = async (
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
-  });
+  }) as PurchaseOrder;
 };
 
 export const deletePurchaseOrder = async (

--- a/itsm_frontend/src/api/serviceRequestApi.ts
+++ b/itsm_frontend/src/api/serviceRequestApi.ts
@@ -12,7 +12,7 @@ import type {
 type AuthenticatedFetch = (
   endpoint: string,
   options?: RequestInit,
-) => Promise<any>;
+) => Promise<unknown>; // Changed Promise<any> to Promise<unknown>
 
 const SERVICE_REQUESTS_ENDPOINT = '/service-requests'; // Removed trailing slash
 

--- a/itsm_frontend/src/context/auth/AuthContext.tsx
+++ b/itsm_frontend/src/context/auth/AuthContext.tsx
@@ -178,7 +178,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   }, [token]); // 'token' is a dependency because backendLogoutApi uses it.
 
   const authenticatedFetch = useCallback(
-    async (endpoint: string, options?: RequestInit): Promise<any> => {
+    async <T = unknown>(endpoint: string, options?: RequestInit): Promise<T> => { // Made generic with T = unknown
       if (!token) {
         console.error('authenticatedFetch: No token available.');
         // Optionally, call logout() here if missing token should always force logout
@@ -187,7 +187,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       }
 
       try {
-        return await apiClient(endpoint, token, options);
+        // Pass generic type T to apiClient
+        const result = await apiClient<T>(endpoint, token!, options);
+        return result;
       } catch (error: unknown) {
         // Check if the error is an instance of AuthError
         if (error instanceof AuthError) {

--- a/itsm_frontend/src/context/auth/AuthContextDefinition.ts
+++ b/itsm_frontend/src/context/auth/AuthContextDefinition.ts
@@ -17,7 +17,7 @@ export interface AuthContextType {
   loading: boolean; // Indicates if authentication state is currently being loaded/initialized
   login: (username: string, password: string) => Promise<boolean>; // Function to handle user login
   logout: () => void; // Function to handle user logout
-  authenticatedFetch: (endpoint: string, options?: RequestInit) => Promise<any>; // Function for making authenticated API calls
+  authenticatedFetch: (endpoint: string, options?: RequestInit) => Promise<unknown>; // Changed Promise<any> to Promise<unknown>
 }
 
 // Creates the React Context object. Default value is undefined, to be provided by AuthProvider.


### PR DESCRIPTION
…pe safety

This commit refactors the `AuthenticatedFetch` type and its usage to enhance type safety in your frontend data fetching layer.

Key changes:

1.  **`AuthContextDefinition.ts`**:
    *   The `AuthenticatedFetch` type signature within `AuthContextType` is changed from `(...) => Promise<any>` to `(...) => Promise<unknown>`.

2.  **API Service Files (`assetApi.ts`, `authApi.ts`, `procurementApi.ts`, `serviceRequestApi.ts`)**:
    *   Local type aliases for `AuthenticatedFetch` (if present) were updated to reflect the `Promise<unknown>` return type.
    *   All calls to `await authenticatedFetch(...)` where the result is used now have explicit type assertions (e.g., `as SpecificResponseType`) to correctly type the data received from the API. This is necessary because `Promise<unknown>` requires you to assert or narrow the type before use.

3.  **`AuthContext.tsx`**:
    *   The `authenticatedFetch` function implementation is now generic: `async <T = unknown>(...) => Promise<T>`.
    *   Its internal call to `apiClient` now uses this generic type: `await apiClient<T>(...)`. This allows `authenticatedFetch` to either return `unknown` (if no type is provided by its caller, which is the case in the API service files) or a more specific type if the caller provides it.

This change makes the data fetching process more type-safe by forcing explicit type handling for API responses, reducing the risk of errors stemming from implicit `any` types.