### PR TITLE
fix: Correct HTML nesting and verify table structures

### DIFF
--- a/itsm_frontend/src/modules/procurement/components/PurchaseOrderDetailView.tsx
+++ b/itsm_frontend/src/modules/procurement/components/PurchaseOrderDetailView.tsx
@@ -147,7 +147,8 @@ const PurchaseOrderDetailView: React.FC = () => {
         <Grid item xs={12} md={6}>
           <Typography variant="h6" gutterBottom>PO Information</Typography>
           <Typography variant="body1"><strong>PO Number:</strong> {purchaseOrder.po_number}</Typography>
-          <Typography variant="body1"><strong>Status:</strong>
+          <Typography component="div" variant="body1" sx={{ display: 'flex', alignItems: 'center' }}> {/* Changed to div and added flex for alignment */}
+            <strong>Status:</strong>
             <Chip
                 label={purchaseOrder.status.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}
                 color={getStatusChipColor(purchaseOrder.status)}


### PR DESCRIPTION
This commit addresses HTML validation warnings you reported:

1.  **Resolved `<div>` in `<p>` Nesting Error**:
    *   In `PurchaseOrderDetailView.tsx`, I modified the `Typography` component displaying the status (which defaults to a `<p>` tag) and containing a `Chip` component (which renders a `<div>`). The `Typography` component now uses `component="div"` and flex styling to ensure valid HTML structure while maintaining visual layout. This fixes the "<div> cannot be a descendant of <p>" warning.

2.  **Investigated Whitespace in Tables**:
    *   I reviewed table structures (`Table`, `TableHead`, `TableBody`, `TableRow`) in all recently developed list components:
        *   `PurchaseOrderDetailView.tsx`
        *   `PurchaseOrderList.tsx`
        *   `CheckRequestList.tsx`
        *   `PurchaseRequestMemoList.tsx`
        *   `AssetList.tsx`
    *   No extraneous whitespace text nodes were found as direct children of `<tr>` or other table structural elements in these files in the current codebase. The components correctly render valid table children directly or through mapping.

These changes improve HTML validity and should prevent related console warnings or hydration errors.