### PR TITLE
Fix: Resolve TypeScript and ESLint errors from your feedback

### DIFF
--- a/itsm_frontend/src/api/assetApi.ts
+++ b/itsm_frontend/src/api/assetApi.ts
@@ -16,6 +16,9 @@ import type {
   GetAssetsParams,
 } from '../modules/assets/types/assetTypes';
 
+// Re-export specific types if they are intended to be available from this API file
+export type { Vendor } from '../modules/assets/types/assetTypes';
+
 const API_BASE_PATH = '/assets'; // Corrected: Relative to global API_BASE_URL (e.g., /api)
 
 // --- AssetCategory Functions ---

--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestForm.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestForm.tsx
@@ -138,7 +138,7 @@ const CheckRequestForm: React.FC = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [authenticatedFetch, showSnackbar]);
+  }, [authenticatedFetch, showSnackbar, purchaseOrders]);
 
   useEffect(() => {
     if (checkRequestId) {
@@ -151,9 +151,8 @@ const CheckRequestForm: React.FC = () => {
       try {
         // Fetch POs that might need a check request (e.g., approved or fully_received)
         // Adjust statuses as per your application's logic
-        // Casting to 'any' for status_in assuming backend supports status__in
         const poData = await getPurchaseOrders(authenticatedFetch, {
-          status_in: ['approved', 'fully_received'] as any,
+          status__in: ['approved', 'fully_received'],
         });
         setPurchaseOrders(poData.results || []);
       } catch (err: unknown) {

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.tsx
@@ -230,12 +230,12 @@ const PurchaseRequestMemoList: React.FC = () => {
           <TableHead>
             <TableRow>
               {headCells.map((headCell) => (
-                <TableCell key={headCell.id} sortDirection={sortConfigKey === headCell.id ? sortConfigDirection : false}>
+                <TableCell key={String(headCell.id)} sortDirection={sortConfigKey === headCell.id ? sortConfigDirection : false}>
                   {headCell.sortable ? (
                     <TableSortLabel
                       active={sortConfigKey === headCell.id}
                       direction={sortConfigKey === headCell.id ? sortConfigDirection : 'asc'}
-                      onClick={() => handleSortRequest(headCell.id)}
+                      onClick={() => handleSortRequest(String(headCell.id))}
                     >
                       {headCell.label}
                     </TableSortLabel>

--- a/itsm_frontend/src/modules/procurement/types/procurementTypes.ts
+++ b/itsm_frontend/src/modules/procurement/types/procurementTypes.ts
@@ -147,9 +147,10 @@ export interface GetPurchaseOrdersParams {
   pageSize?: number;
   ordering?: string;
   status?: PurchaseOrderStatus;
+  status__in?: PurchaseOrderStatus[]; // Added this line
   vendor_id?: number;
   // Add other relevant filter fields
-  [key: string]: string | number | boolean | undefined | PurchaseOrderStatus;
+  [key: string]: string | number | boolean | undefined | PurchaseOrderStatus | PurchaseOrderStatus[];
 }
 
 // --- Check Request Types ---


### PR DESCRIPTION
This commit addresses a list of specific TypeScript and ESLint errors you identified after previous refactoring efforts.

Corrections include:
1.  **Unused Type Declarations (API Files):**
    *   I verified that types previously flagged by ESLint as 'unused' in `procurementApi.ts` and `serviceRequestApi.ts` (e.g., `PurchaseRequestStatus`, `ServiceRequestCategory`) are actually indirectly used as components of other necessary types. No types were removed from these API files based on this re-evaluation.

2.  **Missing Type Export (`assetApi.ts`):**
    *   I ensured the `Vendor` type can be imported from `itsm_frontend/src/api/assetApi.ts` by adding a re-export: `export type { Vendor } from '../modules/assets/types/assetTypes';`. Its definition resides in `assetTypes.ts`.

3.  **Type Import Paths (`PurchaseRequestMemoList.tsx`):**
    *   I verified that type imports for `PurchaseRequestMemo`, `PurchaseRequestDecisionData`, and `GetPurchaseRequestMemosParams` in `PurchaseRequestMemoList.tsx` correctly point to `../../types` (the module's local types), resolving potential errors from attempting to import from old API file paths.

4.  **Explicit `any` (`CheckRequestForm.tsx`):**
    *   I fixed an explicit `any` usage by updating the `GetPurchaseOrdersParams` type in `procurementTypes.ts` to include `status__in?: PurchaseOrderStatus[];` and modified the `getPurchaseOrders` call in `CheckRequestForm.tsx` to use this typed property without `as any`.

5.  **Exhaustive Dependencies (`CheckRequestForm.tsx`):**
    *   I resolved an ESLint `exhaustive-deps` warning by adding the missing `purchaseOrders` dependency to the `useCallback` for `fetchCheckRequest`.

6.  **React `key` Prop Type Error (`PurchaseRequestMemoList.tsx`):**
    *   I addressed a type error for the `key` prop on `TableCell` by explicitly converting the key value to a string: `key={String(headCell.id)}`.

7.  **Function Argument Type Error (`PurchaseRequestMemoList.tsx`):**
    *   I resolved a type error in the `handleSortRequest` call by explicitly converting the `headCell.id` argument to a string: `handleSortRequest(String(headCell.id))`.

These fixes aim to improve code quality, type safety, and resolve reported build/linting issues.