### PR TITLE
Fix 401 Unauthorized errors in Service Catalog module

### DIFF
--- a/itsm_frontend/src/modules/service-catalog/api/serviceCatalogApi.ts
+++ b/itsm_frontend/src/modules/service-catalog/api/serviceCatalogApi.ts
@@ -10,29 +10,29 @@ function processListResponse<T>(response: { data: { results: T[] } | T[] }): T[]
     return response.data as T[];
 }
 
-export const getCatalogCategories = async (): Promise<CatalogCategory[]> => {
+export const getCatalogCategories = async (token: string): Promise<CatalogCategory[]> => {
     const response = await apiClient<{ data: { results: CatalogCategory[] } | CatalogCategory[] }>(
         '/api/service-catalog/categories/',
-        '',
+        token, // Use the passed token
         { method: 'GET' }
     );
     return processListResponse<CatalogCategory>(response);
 };
 
-export const getCatalogItems = async (categoryId?: number | string): Promise<CatalogItem[]> => {
+export const getCatalogItems = async (token: string, categoryId?: number | string): Promise<CatalogItem[]> => {
     const params = categoryId ? `?category=${categoryId}` : '';
     const response = await apiClient<{ data: { results: CatalogItem[] } | CatalogItem[] }>(
         `/api/service-catalog/items/${params}`,
-        '',
+        token, // Use the passed token
         { method: 'GET' }
     );
     return processListResponse<CatalogItem>(response);
 };
 
-export const getCatalogItemById = async (itemId: number | string): Promise<CatalogItem> => {
+export const getCatalogItemById = async (token: string, itemId: number | string): Promise<CatalogItem> => {
     const response = await apiClient<{ data: CatalogItem }>(
         `/api/service-catalog/items/${itemId}/`,
-        '',
+        token, // Use the passed token
         { method: 'GET' }
     );
     return response.data;

--- a/itsm_frontend/src/modules/service-requests/pages/NewServiceRequestPage.tsx
+++ b/itsm_frontend/src/modules/service-requests/pages/NewServiceRequestPage.tsx
@@ -28,7 +28,7 @@ function NewServiceRequestPage() {
   const { id } = useParams<{ id?: string }>();
   const navigate = useNavigate();
   const location = useLocation();
-  const { authenticatedFetch } = useAuth();
+  const { token, authenticatedFetch, loading: authLoading, isAuthenticated } = useAuth(); // Updated useAuth
 
   // Allow catalog_item_id as an extra property for prefill
   const [initialFormData, setInitialFormData] = useState<Partial<ServiceRequest> & { catalog_item_id?: number } | undefined>(undefined);
@@ -70,10 +70,25 @@ function NewServiceRequestPage() {
   useEffect(() => {
     const locationState = location.state as LocationState | null;
     if (locationState?.catalog_item_id && !id) {
-      setLoading(true);
+      // No need to setLoading(true) here, main loading handles authLoading
       const fetchCatalogItem = async () => {
+        if (authLoading) return; // Wait for auth to resolve
+
+        if (!isAuthenticated || !token) {
+          console.error('Cannot fetch catalog item details: User not authenticated or token missing.');
+          setError('Authentication required to fetch catalog item details.');
+          // Set prefill data from location state even if item fetch fails due to auth
+          setPrefillData({
+            catalog_item_id: locationState.catalog_item_id,
+            title: locationState.prefill_title,
+            description: locationState.prefill_description,
+          });
+          setLoading(false); // Ensure loading stops
+          return;
+        }
         try {
-          const item = await getCatalogItemById(locationState.catalog_item_id!);
+          setLoading(true); // Set loading true only when actually fetching
+          const item = await getCatalogItemById(token, locationState.catalog_item_id!);
           setCatalogItemDetails(item);
           setPrefillData({
             catalog_item_id: item.id,
@@ -91,22 +106,33 @@ function NewServiceRequestPage() {
         }
       };
       fetchCatalogItem();
+    } else {
+      // If not fetching catalog item via location state, ensure loading is false
+      // This case might occur if navigating directly to new request page without catalog interaction
+      if (!id) setLoading(false);
     }
-  }, [location.state, id, parseError]);
+  }, [location.state, id, parseError, token, isAuthenticated, authLoading]); // Added auth dependencies
 
   useEffect(() => {
     const fetchInitialOrSetPrefill = async () => {
-      if (id) {
+      if (id) { // Editing an existing request
+        if (authLoading) return; // Wait for auth to resolve for existing requests too
+
+        if (!isAuthenticated || !token) { // Should ideally not happen if getServiceRequestById needs auth
+          console.error('Cannot fetch service request or catalog item details: User not authenticated or token missing.');
+          setError('Authentication is required.');
+          setLoading(false);
+          return;
+        }
         setLoading(true);
         setError(null);
         try {
           const requestData = await getServiceRequestById(authenticatedFetch, id);
           setInitialFormData(requestData);
-          // If editing, also fetch its catalog item if linked, for display consistency
-          // Use catalog_item_id instead of catalog_item
           const reqWithCatalogId = requestData as ServiceRequest & { catalog_item_id?: number };
           if (reqWithCatalogId.catalog_item_id) {
-            const item = await getCatalogItemById(reqWithCatalogId.catalog_item_id);
+            // Fetch linked catalog item
+            const item = await getCatalogItemById(token, reqWithCatalogId.catalog_item_id);
             setCatalogItemDetails(item);
           }
         } catch (err) {
@@ -115,29 +141,42 @@ function NewServiceRequestPage() {
         } finally {
           setLoading(false);
         }
-      } else if (prefillData.catalog_item_id) {
+      } else if (prefillData.catalog_item_id) { // Creating new request with prefill from (potentially failed) catalog item fetch
         setInitialFormData({
           title: prefillData.title || '',
           description: prefillData.description || '',
-          catalog_item_id: prefillData.catalog_item_id, // Use catalog_item_id for prefill
+          catalog_item_id: prefillData.catalog_item_id,
         });
-        setLoading(false);
-      } else {
+        // setLoading(false) should have been handled by the first useEffect if catalog item was fetched
+        // or if it failed due to auth. If here, it means first effect didn't run or completed.
+        if (!(location.state as LocationState)?.catalog_item_id) setLoading(false);
+      } else { // Creating a brand new request without any prefill
         setLoading(false);
         setInitialFormData(undefined);
       }
     };
 
+    // Condition to run this effect:
+    // 1. If `id` is present (editing).
+    // 2. Or, if `prefillData` has been populated (by the first effect).
+    // 3. Or, if there was no `catalog_item_id` in location.state to trigger the first effect (direct navigation to new).
     if (id || Object.keys(prefillData).length > 0 || !(location.state as LocationState)?.catalog_item_id) {
-      fetchInitialOrSetPrefill();
+        if (!authLoading) { // Only proceed if auth state is resolved
+            fetchInitialOrSetPrefill();
+        } else if (!id && !(location.state as LocationState)?.catalog_item_id) {
+            // If creating a new blank request and auth is still loading, set loading to true
+            // to prevent form rendering prematurely.
+            setLoading(true);
+        }
     }
-  }, [id, authenticatedFetch, parseError, prefillData, location.state]);
+  }, [id, authenticatedFetch, parseError, prefillData, location.state, token, isAuthenticated, authLoading]); // Added auth dependencies
 
   const pageTitle = id
     ? `Edit Service Request: ${id}`
     : 'Create New Service Request';
 
-  if (loading) {
+  // Consider authLoading in the main loading check
+  if (loading || authLoading && id) { // For existing requests, authLoading implies main loading
     return (
       <Box
         sx={{


### PR DESCRIPTION
This commit addresses 401 Unauthorized errors you encountered when accessing Service Catalog API endpoints. The errors were due to authentication tokens not being correctly passed to the apiClient.

Key changes:

1.  **`serviceCatalogApi.ts` Updated:**
    *   Functions `getCatalogCategories`, `getCatalogItems`, and `getCatalogItemById` were modified to accept an authentication `token` as an argument.
    *   These functions now pass the received `token` to the `apiClient` for inclusion in the `Authorization` header.

2.  **`CatalogPage.tsx` Updated:**
    *   Integrated `useAuth()` to retrieve the `token`, `authLoading`, and `isAuthenticated` states.
    *   Modified API calls (`getCatalogCategories`, `getCatalogItems`) to pass the obtained `token`.
    *   Enhanced loading and authentication state handling:
        *   API calls are now conditional on your authentication and token availability.
        *   Displays appropriate messages or loading indicators based on the authentication status.

3.  **`NewServiceRequestPage.tsx` Updated:**
    *   Integrated `useAuth()` more thoroughly to use `token`, `authLoading`, and `isAuthenticated` for guarding API calls.
    *   Modified the call to `getCatalogItemById` to pass the obtained `token`.
    *   Improved handling of loading and authentication states, especially when fetching catalog item details for pre-filling forms or viewing existing linked items.

These changes ensure that API requests originating from the Service Catalog module are properly authenticated, resolving the 401 errors.