### PR TITLE
Hi, I'm Jules, your AI coding agent.

### DIFF
--- a/itsm_frontend/src/modules/service-catalog/pages/CatalogPage.tsx
+++ b/itsm_frontend/src/modules/service-catalog/pages/CatalogPage.tsx
@@ -151,11 +151,11 @@ const CatalogPage: React.FC = () => {
           <AccordionDetails>
             {category.description && <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>{category.description}</Typography>}
             {loadingItems[category.id] && <CircularProgress size={24} />}
-            {!loadingItems[category.id] && itemsByCategory[category.id]?.length === 0 && (
+            {!loadingItems[category.id] && Array.isArray(itemsByCategory[category.id]) && itemsByCategory[category.id].length === 0 && (
               <Typography>No items found in this category.</Typography>
             )}
             <Grid container spacing={2}>
-              {itemsByCategory[category.id]?.map((item) => (
+              {Array.isArray(itemsByCategory[category.id]) && itemsByCategory[category.id].map((item) => (
                 <Grid item xs={12} sm={6} md={4} key={item.id}>
                   <Card sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
                     <CardContent sx={{ flexGrow: 1 }}>


### PR DESCRIPTION
I've made some changes to `CatalogPage.tsx` to add robust `Array.isArray` checks.

This commit adds explicit `Array.isArray()` checks before accessing `.length` or calling `.map()` on `itemsByCategory[category.id]` in `CatalogPage.tsx`.

This is a further safeguard against the persisting TypeError: "Cannot read properties of undefined (reading 'length')", even after optional chaining (`?.`) was implemented.

The changes are:
- Condition for "No items found": `{!loadingItems[category.id] && Array.isArray(itemsByCategory[category.id]) && itemsByCategory[category.id].length === 0 && ...}`
- Condition for mapping items: `{Array.isArray(itemsByCategory[category.id]) && itemsByCategory[category.id].map(...)}`

This aims to prevent the TypeError if `itemsByCategory[category.id]` is in an unexpected state (e.g., defined but not an array).