### PR TITLE
Comprehensive fixes for auth, API calls, and runtime errors

### DIFF
--- a/itsm_frontend/src/modules/changes/pages/ChangeManagementPage.tsx
+++ b/itsm_frontend/src/modules/changes/pages/ChangeManagementPage.tsx
@@ -8,7 +8,7 @@ import type { ChangeRequest, NewChangeRequestData } from '../types';
 import { getChangeRequests, deleteChangeRequest, createChangeRequest, updateChangeRequest } from '../api';
 import { useUI } from '../../../context/UIContext/useUI';
 import { useAuth } from '../../../context/auth/useAuth'; // Import useAuth
-import type { AuthenticatedFetch } from '../../../context/auth/AuthContextDefinition'; // Import AuthenticatedFetch type
+// import type { AuthenticatedFetch } from '../../../context/auth/AuthContextDefinition'; // Import AuthenticatedFetch type - Removed as unused for explicit annotation
 import ChangeRequestForm from '../components/ChangeRequestForm';
 
 const ChangeManagementPage: React.FC = () => {

--- a/itsm_frontend/src/modules/configs/pages/ConfigurationManagementPage.tsx
+++ b/itsm_frontend/src/modules/configs/pages/ConfigurationManagementPage.tsx
@@ -8,7 +8,7 @@ import { type ConfigurationItem, type NewConfigurationItemData } from '../types'
 import { getConfigItems, deleteConfigItem, createConfigItem, updateConfigItem } from '../api';
 import { useUI } from '../../../context/UIContext/useUI';
 import { useAuth } from '../../../context/auth/useAuth'; // Import useAuth
-import type { AuthenticatedFetch } from '../../../context/auth/AuthContextDefinition'; // Import AuthenticatedFetch type
+// import type { AuthenticatedFetch } from '../../../context/auth/AuthContextDefinition'; // Import AuthenticatedFetch type - Removed as unused for explicit annotation
 import ConfigurationItemForm from '../components/ConfigurationItemForm';
 
 const ConfigurationManagementPage: React.FC = () => {

--- a/itsm_frontend/src/modules/workflows/pages/MyApprovalsPage.tsx
+++ b/itsm_frontend/src/modules/workflows/pages/MyApprovalsPage.tsx
@@ -9,7 +9,7 @@ import { type ApprovalStep, type ApprovalActionPayload } from '../types';
 import { getMyApprovalSteps, approveStep, rejectStep, getApprovalRequestById } from '../api';
 import { useUI } from '../../../context/UIContext/useUI';
 import { useAuth } from '../../../context/auth/useAuth'; // Import useAuth
-import type { AuthenticatedFetch } from '../../../context/auth/AuthContextDefinition'; // Import AuthenticatedFetch type
+// import type { AuthenticatedFetch } from '../../../context/auth/AuthContextDefinition'; // Removed as it's unused for explicit type annotation
 
 const MyApprovalsPage: React.FC = () => {
   const { showSnackbar } = useUI();
@@ -103,17 +103,23 @@ const MyApprovalsPage: React.FC = () => {
     const payload: ApprovalActionPayload = { comments };
     try {
       if (actionType === 'approve') {
-        await approveStep(authenticatedFetch, currentStep.id, payload); // Pass authenticatedFetch
+        await approveStep(authenticatedFetch, currentStep.id, payload);
         showSnackbar('Step approved successfully!', 'success');
-      } else {
-        await rejectStep(authenticatedFetch, currentStep.id, payload); // Pass authenticatedFetch
+      } else if (actionType === 'reject') {
+        await rejectStep(authenticatedFetch, currentStep.id, payload);
         showSnackbar('Step rejected successfully!', 'success');
+      } else {
+        console.error("Invalid actionType in handleSubmitAction:", actionType);
+        showSnackbar(`Invalid action: ${actionType}`, 'error');
+        setIsSubmittingAction(false); // Reset loading if action is invalid
+        return;
       }
-      await fetchMyPendingSteps(); // Refresh list
+      await fetchMyPendingSteps();
       handleCloseActionDialog();
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : `Failed to ${actionType} step.`;
       showSnackbar(errorMsg, 'error');
+      // Dialog remains open for user to retry or cancel
     } finally {
       setIsSubmittingAction(false);
     }


### PR DESCRIPTION
This commit consolidates a series of fixes and refactorings to address authentication issues (401s), API path errors (404s), runtime TypeErrors, and TypeScript/ESLint errors across multiple modules. The primary goal was to ensure consistent and correct use of the `authenticatedFetch` pattern from AuthContext for all authenticated API calls.

**Key Changes:**

1.  **Standardized `authenticatedFetch` Usage:**
    *   Defined and exported `AuthenticatedFetch` type from
        `AuthContextDefinition.ts`.
    *   Refactored API utility functions in `serviceCatalogApi.ts`,
        `configItemApi.ts`, `changeRequestApi.ts`, and `workflowApi.ts`
        to accept `authenticatedFetch: AuthenticatedFetch` as their first
        argument and use it for API calls.
    *   Updated all relevant page and form components (Catalog,
        Service Requests prefill, Configs page & form, Changes page & form,
        My Approvals page) to correctly obtain `authenticatedFetch` from
        `useAuth()` and pass it with the correct arguments to the API
        utility functions.

2.  **Resolved 401 Unauthorized Errors:**
    *   Ensured proper token handling via the `authenticatedFetch`
        mechanism across all refactored modules.

3.  **Resolved 404 Not Found Errors:**
    *   Corrected API endpoint paths in all API utility files by removing
        the redundant leading `/api` prefix.

4.  **Fixed Runtime TypeErrors:**
    *   In `CatalogPage.tsx`, resolved "Cannot read properties of undefined
        (reading 'length')" by implementing robust checks using optional
        chaining (`?.`) and `Array.isArray()` for `itemsByCategory` and
        `categories` where appropriate.

5.  **Corrected TypeScript & ESLint Errors:**
    *   Fixed type errors in `ChangeRequestForm.tsx` related to the
        display of approval information.
    *   Resolved syntax errors (useCallback dependencies, try/catch blocks)
        in `MyApprovalsPage.tsx`.
    *   Cleaned up unused `AuthenticatedFetch` type imports in page components
        where type inference was sufficient.

6.  **Addressed Initial Requirements:**
    *   Sidebar links for 'Service Catalog' and 'My Approvals' added.
    *   Core functionality of Service Catalog, Config Management,
        Change Management, and My Approvals pages verified and enhanced.
    *   Approval display in `ChangeRequestForm.tsx` implemented (with the
        `CHANGES_CONTENT_TYPE_ID` placeholder still needing replacement).

This comprehensive set of changes aims to provide a stable, consistent, and correctly functioning authentication and API interaction layer for the affected modules.