### PR TITLE
fix: Align API client and form submissions for FormData

### DIFF
--- a/itsm_frontend/src/api/procurementApi.ts
+++ b/itsm_frontend/src/api/procurementApi.ts
@@ -53,13 +53,13 @@ export const getPurchaseRequestMemos = async (
 
 export const createPurchaseRequestMemo = async (
   authenticatedFetch: AuthenticatedFetch,
-  data: PurchaseRequestMemoData,
+  data: FormData, // Changed from PurchaseRequestMemoData
 ): Promise<PurchaseRequestMemo> => {
   const endpoint = `${API_PROCUREMENT_PATH}/memos/`;
   return (await authenticatedFetch(endpoint, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    // headers: { 'Content-Type': 'application/json' }, // Remove for FormData
+    body: data, // Pass FormData directly
   })) as PurchaseRequestMemo;
 };
 
@@ -76,13 +76,13 @@ export const getPurchaseRequestMemoById = async (
 export const updatePurchaseRequestMemo = async (
   authenticatedFetch: AuthenticatedFetch,
   id: number,
-  data: Partial<PurchaseRequestMemoUpdateData>,
+  data: FormData, // Changed from Partial<PurchaseRequestMemoUpdateData>
 ): Promise<PurchaseRequestMemo> => {
   const endpoint = `${API_PROCUREMENT_PATH}/memos/${id}/`;
   return (await authenticatedFetch(endpoint, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    method: 'PATCH', // Or PUT, depending on backend. PATCH is typical for FormData updates if partial.
+    // headers: { 'Content-Type': 'application/json' }, // Remove for FormData
+    body: data, // Pass FormData directly
   })) as PurchaseRequestMemo;
 };
 
@@ -139,13 +139,13 @@ export const getPurchaseOrders = async (
 
 export const createPurchaseOrder = async (
   authenticatedFetch: AuthenticatedFetch,
-  data: PurchaseOrderData,
+  data: FormData, // Changed from PurchaseOrderData
 ): Promise<PurchaseOrder> => {
   const endpoint = `${API_PROCUREMENT_PATH}/purchase-orders/`;
   return (await authenticatedFetch(endpoint, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    // headers: { 'Content-Type': 'application/json' }, // Remove for FormData
+    body: data, // Pass FormData directly
   })) as PurchaseOrder;
 };
 
@@ -162,13 +162,13 @@ export const getPurchaseOrderById = async (
 export const updatePurchaseOrder = async (
   authenticatedFetch: AuthenticatedFetch,
   id: number,
-  data: Partial<PurchaseOrderData>,
+  data: FormData, // Changed from Partial<PurchaseOrderData>
 ): Promise<PurchaseOrder> => {
   const endpoint = `${API_PROCUREMENT_PATH}/purchase-orders/${id}/`;
   return (await authenticatedFetch(endpoint, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    method: 'PATCH', // Or PUT
+    // headers: { 'Content-Type': 'application/json' }, // Remove for FormData
+    body: data, // Pass FormData directly
   })) as PurchaseOrder;
 };
 
@@ -210,13 +210,13 @@ export const getCheckRequests = async (
 
 export const createCheckRequest = async (
   authenticatedFetch: AuthenticatedFetch,
-  data: CheckRequestData,
+  data: FormData, // Changed from CheckRequestData
 ): Promise<CheckRequest> => {
   const endpoint = `${API_PROCUREMENT_PATH}/check-requests/`;
   return (await authenticatedFetch(endpoint, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    // headers: { 'Content-Type': 'application/json' }, // Remove for FormData
+    body: data, // Pass FormData directly
   })) as CheckRequest;
 };
 
@@ -233,13 +233,13 @@ export const getCheckRequestById = async (
 export const updateCheckRequest = async (
   authenticatedFetch: AuthenticatedFetch,
   id: number,
-  data: Partial<CheckRequestUpdateData>,
+  data: FormData, // Changed from Partial<CheckRequestUpdateData>
 ): Promise<CheckRequest> => {
   const endpoint = `${API_PROCUREMENT_PATH}/check-requests/${id}/`;
   return (await authenticatedFetch(endpoint, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    method: 'PATCH', // Or PUT
+    // headers: { 'Content-Type': 'application/json' }, // Remove for FormData
+    body: data, // Pass FormData directly
   })) as CheckRequest;
 };
 

--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestForm.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestForm.tsx
@@ -403,11 +403,11 @@ const CheckRequestForm: React.FC = () => {
         await updateCheckRequest(
           authenticatedFetch,
           formData.id,
-          submissionPayload as FormData,
+          submissionPayload, // No longer need 'as FormData'
         );
         showSnackbar('Check Request updated successfully!', 'success');
       } else {
-        await createCheckRequest(authenticatedFetch, submissionPayload as FormData);
+        await createCheckRequest(authenticatedFetch, submissionPayload); // No longer need 'as FormData'
         showSnackbar('Check Request created successfully!', 'success');
       }
       navigate('/procurement/check-requests');

--- a/itsm_frontend/src/modules/procurement/components/purchase-orders/PurchaseOrderForm.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-orders/PurchaseOrderForm.tsx
@@ -477,11 +477,11 @@ const PurchaseOrderForm: React.FC = () => {
         await updatePurchaseOrder(
           authenticatedFetch,
           parseInt(poId, 10),
-          submissionPayload as FormData,
+          submissionPayload, // No longer need 'as FormData'
         );
         showSnackbar('Purchase Order updated successfully!', 'success');
       } else {
-        await createPurchaseOrder(authenticatedFetch, submissionPayload as FormData);
+        await createPurchaseOrder(authenticatedFetch, submissionPayload); // No longer need 'as FormData'
         showSnackbar('Purchase Order created successfully!', 'success');
       }
       navigate('/procurement/purchase-orders'); // Adjust navigation path

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoForm.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoForm.tsx
@@ -244,13 +244,13 @@ const PurchaseRequestMemoForm: React.FC = () => {
         await updatePurchaseRequestMemo(
           authenticatedFetch,
           parseInt(memoId, 10),
-          submissionPayload as FormData,
+          submissionPayload, // No longer need 'as FormData'
         );
         showSnackbar('Purchase request updated successfully!', 'success');
       } else {
         await createPurchaseRequestMemo(
           authenticatedFetch,
-          submissionPayload as FormData,
+          submissionPayload, // No longer need 'as FormData'
         );
         showSnackbar('Purchase request created successfully!', 'success');
       }


### PR DESCRIPTION
- Updated API client functions in procurementApi.ts (create/update for IOM, PO, CR) to accept FormData directly for the 'data' parameter and removed 'Content-Type: application/json' headers for these requests. This allows the browser to correctly set the multipart/form-data header.
- Removed 'as FormData' casts in the handleSubmit methods of PurchaseRequestMemoForm.tsx, PurchaseOrderForm.tsx, and CheckRequestForm.tsx, as the API client functions now correctly expect FormData.
- This resolves TypeScript errors related to passing FormData to functions expecting plain data objects and ensures proper handling of file uploads.