### PR TITLE
FEAT: Add initial tests for procurement forms

### DIFF
--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestForm.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestForm.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+// fireEvent removed as it's not used yet
+import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import * as ReactRouterDom from 'react-router-dom';
 import { UIContextProvider as UIProvider } from '../../../../context/UIContext/UIContextProvider';
@@ -8,22 +9,30 @@ import { AuthProvider } from '../../../../context/auth/AuthContext';
 
 // Mock API dependencies
 import * as procurementApi from '../../../../api/procurementApi';
-import * as assetApi from '../../../../api/assetApi'; // If vendors/other assets needed
+import * as assetApi from '../../../../api/assetApi';
+
+// Define a PaginatedResponse type helper for mocks
+type MockPaginatedResponse<T> = {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+};
 
 vi.mock('../../../../api/procurementApi', () => ({
   getCheckRequestById: vi.fn(),
   createCheckRequest: vi.fn(),
   updateCheckRequest: vi.fn(),
-  getPurchaseOrdersForCheckRequest: vi.fn(() => Promise.resolve({ results: [], count: 0 })),
-  getPurchaseOrders: vi.fn(() => Promise.resolve({ results: [], count: 0 })), // Added this
-  getDepartments: vi.fn(() => Promise.resolve([])),
-  getProjects: vi.fn(() => Promise.resolve([])),
-  getExpenseCategories: vi.fn(() => Promise.resolve([])),
-  getGLAccounts: vi.fn(() => Promise.resolve({ results: [], count: 0 })),
+  // getPurchaseOrdersForCheckRequest: vi.fn(), // This seems unused by the component, removing from mock
+  getPurchaseOrders: vi.fn((): Promise<MockPaginatedResponse<unknown>> => Promise.resolve({ results: [], count: 0, next: null, previous: null })), // Corrected, component uses this
+  getDepartments: vi.fn((): Promise<MockPaginatedResponse<unknown>> => Promise.resolve({ results: [], count: 0, next: null, previous: null })),  // Adjusted for PaginatedResponse
+  getProjects: vi.fn((): Promise<MockPaginatedResponse<unknown>> => Promise.resolve({ results: [], count: 0, next: null, previous: null })), // Adjusted for PaginatedResponse
+  getExpenseCategories: vi.fn((): Promise<MockPaginatedResponse<unknown>> => Promise.resolve({ results: [], count: 0, next: null, previous: null })), // Adjusted for PaginatedResponse
+  // getGLAccounts is not used by CheckRequestForm, removing from this specific mock
 }));
 
 vi.mock('../../../../api/assetApi', () => ({
-  getVendors: vi.fn(() => Promise.resolve({ results: [], count: 0 })),
+  getVendors: vi.fn((): Promise<MockPaginatedResponse<Partial<import('../../../../api/assetApi').Vendor>>> => Promise.resolve({ results: [], count: 0, next: null, previous: null })),
 }));
 
 vi.mock('react-router-dom', async () => {
@@ -40,14 +49,8 @@ const mockAuthenticatedFetch = vi.fn();
 const renderWithProviders = (ui: React.ReactElement) => {
   return render(
     <BrowserRouter>
-      <AuthProvider value={{
-        user: { id: 1, username: 'testuser', email: 'test@example.com', roles: ['admin'] },
-        authenticatedFetch: mockAuthenticatedFetch,
-        login: vi.fn(),
-        logout: vi.fn(),
-        loading: false,
-        isAuthenticated: true,
-       }}>
+      {/* AuthProvider does not take a value prop directly, it provides context internally */}
+      <AuthProvider>
         <UIProvider>
           {ui}
         </UIProvider>
@@ -61,9 +64,10 @@ describe('CheckRequestForm', () => {
     vi.clearAllMocks();
     vi.mocked(ReactRouterDom.useParams).mockReturnValue({});
     // Reset mocks for API calls that return promises with specific data for each test if needed
-    vi.mocked(procurementApi.getPurchaseOrdersForCheckRequest).mockResolvedValue({ results: [], count: 0 });
-    vi.mocked(assetApi.getVendors).mockResolvedValue({ results: [], count: 0 });
-    vi.mocked(procurementApi.getGLAccounts).mockResolvedValue({ results: [], count: 0 });
+    vi.mocked(procurementApi.getPurchaseOrders).mockResolvedValue({ results: [], count: 0, next: null, previous: null });
+    vi.mocked(assetApi.getVendors).mockResolvedValue({ results: [], count: 0, next: null, previous: null } as MockPaginatedResponse<Partial<import('../../../../api/assetApi').Vendor>>);
+    // getGLAccounts is not used by CheckRequestForm, so no need to reset its mock here
+    // getPurchaseOrdersForCheckRequest is not used, removed from mock and here
   });
 
   it('renders the form in create mode', async () => {
@@ -73,34 +77,34 @@ describe('CheckRequestForm', () => {
 
   it('renders the form in edit mode when checkRequestId is provided', async () => {
     const mockCrId = 'cr123';
+    const numericMockCrId = 123; // Assuming ID is number
     vi.mocked(ReactRouterDom.useParams).mockReturnValue({ checkRequestId: mockCrId });
 
     vi.mocked(procurementApi.getCheckRequestById).mockResolvedValue({
-      id: mockCrId, // Should match component's expectation (string or number)
-      cr_number: 'CR-001', // Displayed in header
-      purchase_order: null, // or a PO id if testing linked PO
-      vendor_id: 1, // Or payee_name if not from PO
+      id: numericMockCrId,
+      cr_number: 'CR-001',
+      purchase_order: null,
+      vendor_id: 1,
       payee_name: 'Mock Payee from Edit',
       payee_address: '123 Mock St',
       invoice_number: 'INV-EDIT-001',
-      invoice_date: '2024-06-15', // YYYY-MM-DD format
-      amount: '1250.75', // String, as component uses it
-      reason_for_payment: 'Test CR for edit', // This is the description
-      expense_category: null, // or an ID
+      invoice_date: '2024-06-15',
+      amount: '1250.75',
+      reason_for_payment: 'Test CR for edit',
+      expense_category: null,
       is_urgent: false,
-      recurring_payment: null, // or an ID
-      currency: 'USD', // Valid currency
-      status: 'draft', // To ensure it's editable and has correct title part
+      recurring_payment: null,
+      currency: 'USD',
+      status: 'draft' as 'draft', // Cast to CheckRequestStatus type
       request_date: '2024-07-01T00:00:00Z',
       requested_by_username: 'testuser',
-      // attachments: null, // Or a mock URL string
-      // Ensure all fields expected by `setFormData` in `fetchCheckRequest` are here
+      // attachments: null,
     });
 
     renderWithProviders(<CheckRequestForm />);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Edit Check Request #cr123/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /Edit Check Request #123/i })).toBeInTheDocument(); // Corrected ID
       expect(screen.getByDisplayValue('Test CR for edit')).toBeInTheDocument(); // Checks reason_for_payment
       expect(screen.getByDisplayValue('Mock Payee from Edit')).toBeInTheDocument();
       expect(screen.getByDisplayValue('1250.75')).toBeInTheDocument();
@@ -121,11 +125,25 @@ describe('CheckRequestForm', () => {
   });
 
   it('submits the form successfully in create mode', async () => {
-    vi.mocked(assetApi.getVendors).mockResolvedValue({ results: [{id: 1, name: "Test Vendor Payee", contact_person: "", email: "", phone: ""}], count: 1 });
+    // Provide a Vendor mock that matches the Vendor type (e.g., no 'phone' if not in type)
+    // Also ensure it's a PaginatedResponse
+    vi.mocked(assetApi.getVendors).mockResolvedValue({
+      results: [{id: 1, name: "Test Vendor Payee", contact_person: "", email: "payee@example.com", /* other required Vendor fields */ }],
+      count: 1,
+      next: null,
+      previous: null
+    } as MockPaginatedResponse<Partial<import('../../../../api/assetApi').Vendor>>);
 
-    const mockCreateCR = vi.mocked(procurementApi.createCheckRequest).mockResolvedValue({
-      id: 'cr-new-id',
-      // ... other fields ...
+    // const mockCreateCR = vi.mocked(procurementApi.createCheckRequest).mockResolvedValue({ // This line is unused for now
+    vi.mocked(procurementApi.createCheckRequest).mockResolvedValue({
+      id: 12345, // Assuming ID is number
+      // ... other fields based on CheckRequest type ...
+      cr_number: "CR-NEW-001",
+      status: 'pending_approval' as 'pending_approval', // Valid CheckRequestStatus
+      amount: "500.00",
+      request_date: new Date().toISOString(),
+      payee_name: "Test Vendor Payee",
+      // ... other required fields from CheckRequest
     });
 
     renderWithProviders(<CheckRequestForm />);

--- a/procurement/cr_attachments/api_cr_attach_lhr7v0D.txt
+++ b/procurement/cr_attachments/api_cr_attach_lhr7v0D.txt
@@ -1,0 +1,1 @@
+api_cr_content

--- a/procurement/cr_attachments/cr_attach_doqkqzB.txt
+++ b/procurement/cr_attachments/cr_attach_doqkqzB.txt
@@ -1,0 +1,1 @@
+cr_content

--- a/procurement/iom_attachments/api_iom_attach_vSQpmVv.txt
+++ b/procurement/iom_attachments/api_iom_attach_vSQpmVv.txt
@@ -1,0 +1,1 @@
+api_iom_content

--- a/procurement/iom_attachments/iom_attach_L7xupiY.txt
+++ b/procurement/iom_attachments/iom_attach_L7xupiY.txt
@@ -1,0 +1,1 @@
+iom_content

--- a/procurement/po_attachments/api_po_attach_ruI2YRm.txt
+++ b/procurement/po_attachments/api_po_attach_ruI2YRm.txt
@@ -1,0 +1,1 @@
+api_po_content

--- a/procurement/po_attachments/api_po_attach_updated_luL6U6Q.txt
+++ b/procurement/po_attachments/api_po_attach_updated_luL6U6Q.txt
@@ -1,0 +1,1 @@
+updated_content

--- a/procurement/po_attachments/po_attach_H5yQix7.txt
+++ b/procurement/po_attachments/po_attach_H5yQix7.txt
@@ -1,0 +1,1 @@
+po_content


### PR DESCRIPTION
- Created PurchaseOrderForm.test.tsx from scratch.
- Created CheckRequestForm.test.tsx from scratch.
- Created PurchaseRequestMemoForm.test.tsx from scratch.

- Debugged and fixed issues in these new test files related to:
  - API mocking (procurementApi, assetApi functions and return types).
  - React Router DOM mocking (`useParams`).
  - UI Context Provider import paths.
  - Element selectors (button names, Autocomplete, date fields, item fields).
  - Test logic for adding/removing items and form submission.
  - Mock data completeness and type correctness for edit modes.
- Addressed various ESLint and TypeScript errors in the new test files, including unused variables, type mismatches for props and mocked data, and ensuring paginated responses included `next` and `previous` fields.

All three new test suites now have basic placeholder tests passing. All existing frontend and backend tests continue to pass.

Note: Some non-critical `act(...)` warnings and MUI select value warnings persist in the frontend test console output but do not currently cause test failures. Further test enhancements for these forms can be done in subsequent tasks.