### PR TITLE
Consolidated fixes for admin, Pylance, and frontend linting.

### DIFF
--- a/itsm_frontend/src/modules/iomTemplateAdmin/types/iomTemplateAdminTypes.ts
+++ b/itsm_frontend/src/modules/iomTemplateAdmin/types/iomTemplateAdminTypes.ts
@@ -27,9 +27,7 @@ export interface FieldDefinition {
   options?: Array<{ value: string | number; label: string }>;
   section?: string; // "header" | "body" | "footer"
   readonly?: boolean;
-  // Record<string, any> is often acceptable for HTML attributes due to their diverse nature.
-  // Could be narrowed to Record<string, string | number | boolean | undefined> if desired.
-  attributes?: Record<string, any>;
+  attributes?: Record<string, string | number | boolean | undefined>; // Narrowed type from any
   api_source?: { // For dynamic dropdowns
       endpoint: string;
       value_field: string;


### PR DESCRIPTION
This commit addresses:
- Django Admin SystemCheckErrors in `procurement/admin.py` related to GenericForeignKey on `ApprovalStep`.
- Pylance/ESLint/TypeScript errors in frontend `iomTemplateAdmin` components and types:
  - Corrected type imports for `AuthenticatedFetch` and `PaginatedResponse` in `genericIomApi.ts`.
  - Removed unused imports/variables and improved type safety (e.g., `any` to `unknown` or more specific types) in `IomTemplateForm.tsx`, `IomTemplateList.tsx`, and `iomTemplateAdminTypes.ts`.
  - Addressed handling of error variables in `catch` blocks.
- Pylance import errors in backend `generic_iom` app:
  - Added missing `Q` and `serializers` imports in `generic_iom/views.py`.
  - Ensured `Q` import is present in `generic_iom/tests/test_models.py`.