### PR TITLE
Implemented frontend for Generic IOM creation and viewing.

### DIFF
--- a/itsm_frontend/src/App.tsx
+++ b/itsm_frontend/src/App.tsx
@@ -54,6 +54,12 @@ const CatalogPage = lazy(() => import('./modules/service-catalog/pages/CatalogPa
 const IomTemplateListPage = lazy(() => import('./modules/iomTemplateAdmin/pages/IomTemplateListPage'));
 const IomTemplateFormPage = lazy(() => import('./modules/iomTemplateAdmin/pages/IomTemplateFormPage'));
 
+// Generic IOM User Pages
+const GenericIomListPage = lazy(() => import('./modules/genericIom/pages/GenericIomListPage'));
+const SelectIomTemplatePage = lazy(() => import('./modules/genericIom/pages/SelectIomTemplatePage'));
+const GenericIomFormPage = lazy(() => import('./modules/genericIom/pages/GenericIomFormPage'));
+const GenericIomDetailPage = lazy(() => import('./modules/genericIom/pages/GenericIomDetailPage'));
+
 
 function AppContent() {
   return (
@@ -180,6 +186,13 @@ function AppContent() {
               <Route path="admin/iom-templates" element={<IomTemplateListPage />} />
               <Route path="admin/iom-templates/new" element={<IomTemplateFormPage />} />
               <Route path="admin/iom-templates/edit/:templateId" element={<IomTemplateFormPage />} />
+
+              {/* Generic IOM User Routes */}
+              <Route path="ioms" element={<GenericIomListPage />} />
+              <Route path="ioms/new/select-template" element={<SelectIomTemplatePage />} />
+              <Route path="ioms/new/:templateId" element={<GenericIomFormPage />} /> {/* Create */}
+              <Route path="ioms/edit/:iomId" element={<GenericIomFormPage />} />    {/* Edit */}
+              <Route path="ioms/view/:iomId" element={<GenericIomDetailPage />} />
             </Route>
             {/* Fallback for unmatched routes */}
             <Route path="*" element={<NotFoundPage />} />

--- a/itsm_frontend/src/api/genericIomApi.ts
+++ b/itsm_frontend/src/api/genericIomApi.ts
@@ -9,8 +9,15 @@ import type {
   IOMTemplateCreateData,
   IOMTemplateUpdateData,
   GetIomTemplatesParams,
-  // GenericIOM related types would also go here or in a separate section if this file grows
-} from '../modules/iomTemplateAdmin/types/iomTemplateAdminTypes'; // Path to the new types
+} from '../modules/iomTemplateAdmin/types/iomTemplateAdminTypes';
+
+import type {
+  GenericIOM,
+  GenericIOMCreateData,
+  GenericIOMUpdateData,
+  GetGenericIomsParams,
+  GenericIomSimpleActionPayload,
+} from '../modules/genericIom/types/genericIomTypes'; // Path to the new GenericIOM types
 
 const API_GENERIC_IOM_BASE_PATH = '/api/generic-iom';
 
@@ -100,9 +107,121 @@ export const deleteIomTemplate = async (
 
 
 // --- GenericIOM Instance API Functions ---
-// These would be added later when implementing GenericIOM forms/lists.
-// For now, this file focuses on Template and Category management APIs.
-// Example:
-// import { GenericIOM, GenericIOMCreateData, ... } from '../modules/iomTemplateAdmin/types/iomTemplateAdminTypes';
-// export const createGenericIom = async (authenticatedFetch: AuthenticatedFetch, data: GenericIOMCreateData): Promise<GenericIOM> => { ... }
-// ... etc. ...
+
+export const getGenericIoms = async (
+  authenticatedFetch: AuthenticatedFetch,
+  params?: GetGenericIomsParams
+): Promise<PaginatedResponse<GenericIOM>> => {
+  const queryParams = new URLSearchParams();
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        if (key === 'pageSize') queryParams.append('page_size', String(value));
+        // Example: map frontend param 'iom_template_id' to backend 'iom_template'
+        else if (key === 'iom_template_id') queryParams.append('iom_template', String(value));
+        else if (key === 'created_by_id') queryParams.append('created_by', String(value));
+        else if (Array.isArray(value)) { // Handle array params like status__in
+            value.forEach(v => queryParams.append(`${key}__in`, String(v)));
+        }
+        else queryParams.append(key, String(value));
+      }
+    });
+  }
+  const endpoint = `${API_GENERIC_IOM_BASE_PATH}/ioms/${queryParams.toString() ? '?' : ''}${queryParams.toString()}`;
+  return (await authenticatedFetch(endpoint, { method: 'GET' })) as PaginatedResponse<GenericIOM>;
+};
+
+export const getGenericIomById = async (
+  authenticatedFetch: AuthenticatedFetch,
+  iomId: number
+): Promise<GenericIOM> => {
+  const endpoint = `${API_GENERIC_IOM_BASE_PATH}/ioms/${iomId}/`;
+  return (await authenticatedFetch(endpoint, { method: 'GET' })) as GenericIOM;
+};
+
+export const createGenericIom = async (
+  authenticatedFetch: AuthenticatedFetch,
+  data: GenericIOMCreateData
+): Promise<GenericIOM> => {
+  const endpoint = `${API_GENERIC_IOM_BASE_PATH}/ioms/`;
+  // Note: If data includes file uploads for GenericIOM (e.g. if a template field is 'file_upload'),
+  // this would need to use FormData instead of JSON. For now, assuming JSON payload.
+  return (await authenticatedFetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })) as GenericIOM;
+};
+
+export const updateGenericIom = async (
+  authenticatedFetch: AuthenticatedFetch,
+  iomId: number,
+  data: GenericIOMUpdateData
+): Promise<GenericIOM> => {
+  const endpoint = `${API_GENERIC_IOM_BASE_PATH}/ioms/${iomId}/`;
+  return (await authenticatedFetch(endpoint, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })) as GenericIOM;
+};
+
+export const deleteGenericIom = async (
+  authenticatedFetch: AuthenticatedFetch,
+  iomId: number
+): Promise<void> => {
+  const endpoint = `${API_GENERIC_IOM_BASE_PATH}/ioms/${iomId}/`;
+  await authenticatedFetch(endpoint, { method: 'DELETE' });
+};
+
+// --- Custom Actions for GenericIOM ---
+
+export const submitGenericIomForSimpleApproval = async (
+  authenticatedFetch: AuthenticatedFetch,
+  iomId: number,
+  payload?: GenericIomSimpleActionPayload // Optional comments
+): Promise<GenericIOM> => {
+  const endpoint = `${API_GENERIC_IOM_BASE_PATH}/ioms/${iomId}/submit_for_simple_approval/`;
+  return (await authenticatedFetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload || {}),
+  })) as GenericIOM;
+};
+
+export const simpleApproveGenericIom = async (
+  authenticatedFetch: AuthenticatedFetch,
+  iomId: number,
+  payload: GenericIomSimpleActionPayload // Comments required/optional based on backend
+): Promise<GenericIOM> => {
+  const endpoint = `${API_GENERIC_IOM_BASE_PATH}/ioms/${iomId}/simple_approve/`;
+  return (await authenticatedFetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })) as GenericIOM;
+};
+
+export const simpleRejectGenericIom = async (
+  authenticatedFetch: AuthenticatedFetch,
+  iomId: number,
+  payload: GenericIomSimpleActionPayload // Comments likely mandatory by backend
+): Promise<GenericIOM> => {
+  const endpoint = `${API_GENERIC_IOM_BASE_PATH}/ioms/${iomId}/simple_reject/`;
+  return (await authenticatedFetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })) as GenericIOM;
+};
+
+export const publishGenericIom = async (
+  authenticatedFetch: AuthenticatedFetch,
+  iomId: number
+): Promise<GenericIOM> => {
+  const endpoint = `${API_GENERIC_IOM_BASE_PATH}/ioms/${iomId}/publish/`;
+  return (await authenticatedFetch(endpoint, {
+    method: 'POST',
+    // No body needed for a simple publish action unless API expects one
+  })) as GenericIOM;
+};

--- a/itsm_frontend/src/modules/genericIom/components/.gitkeep
+++ b/itsm_frontend/src/modules/genericIom/components/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to create the 'components' directory

--- a/itsm_frontend/src/modules/genericIom/components/DynamicIomFormFieldRenderer.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/DynamicIomFormFieldRenderer.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import {
+  TextField,
+  Checkbox,
+  FormControlLabel,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  FormHelperText,
+  Box,
+  Typography
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'; // Or your preferred date adapter
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import type { FieldDefinition } from '../../iomTemplateAdmin/types/iomTemplateAdminTypes'; // Assuming FieldDefinition is here
+
+interface DynamicFormFieldProps {
+  field: FieldDefinition;
+  value: any;
+  onChange: (fieldName: string, value: any) => void;
+  disabled?: boolean;
+  error?: string | null; // For displaying field-specific errors from parent form
+}
+
+const DynamicIomFormFieldRenderer: React.FC<DynamicFormFieldProps> = ({
+  field,
+  value,
+  onChange,
+  disabled = false,
+  error = null,
+}) => {
+  const commonProps = {
+    name: field.name,
+    label: field.label,
+    required: field.required,
+    fullWidth: true,
+    disabled: disabled || field.readonly,
+    helperText: error || field.helpText,
+    error: Boolean(error),
+    InputLabelProps: { shrink: true }, // Ensure labels shrink correctly, esp for date/time
+  };
+
+  // Handle date/datetime value conversion
+  const handleDateChange = (date: Date | null) => {
+    onChange(field.name, date ? date.toISOString() : null);
+  };
+
+  const handleDateTimeChange = (dateTime: Date | null) => {
+    onChange(field.name, dateTime ? dateTime.toISOString() : null);
+  };
+
+  // For file inputs, we'd need more complex state management in the parent form
+  // For now, file_upload will be a placeholder or a simple text input for filename.
+
+  switch (field.type) {
+    case 'text_short':
+      return (
+        <TextField
+          {...commonProps}
+          type="text"
+          value={value || field.defaultValue || ''}
+          placeholder={field.placeholder}
+          onChange={(e) => onChange(field.name, e.target.value)}
+          inputProps={field.attributes}
+        />
+      );
+    case 'text_area':
+      return (
+        <TextField
+          {...commonProps}
+          type="text"
+          multiline
+          rows={field.attributes?.rows || 4}
+          value={value || field.defaultValue || ''}
+          placeholder={field.placeholder}
+          onChange={(e) => onChange(field.name, e.target.value)}
+          inputProps={field.attributes}
+        />
+      );
+    case 'number':
+      return (
+        <TextField
+          {...commonProps}
+          type="number"
+          value={value === null || value === undefined ? '' : value} // Handle null/undefined for number input
+          placeholder={field.placeholder}
+          onChange={(e) => onChange(field.name, e.target.value === '' ? null : parseFloat(e.target.value))}
+          inputProps={field.attributes} // For min, max, step
+        />
+      );
+    case 'date':
+      return (
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <DatePicker
+            label={field.label}
+            value={value ? new Date(value) : (field.defaultValue ? new Date(field.defaultValue) : null)}
+            onChange={handleDateChange}
+            disabled={disabled || field.readonly}
+            slotProps={{
+                textField: {
+                    fullWidth: true,
+                    required: field.required,
+                    helperText: error || field.helpText,
+                    error: Boolean(error),
+                    InputLabelProps: { shrink: true }
+                }
+            }}
+          />
+        </LocalizationProvider>
+      );
+    case 'datetime':
+        return (
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <DateTimePicker
+              label={field.label}
+              value={value ? new Date(value) : (field.defaultValue ? new Date(field.defaultValue) : null)}
+              onChange={handleDateTimeChange}
+              disabled={disabled || field.readonly}
+              slotProps={{
+                  textField: {
+                      fullWidth: true,
+                      required: field.required,
+                      helperText: error || field.helpText,
+                      error: Boolean(error),
+                      InputLabelProps: { shrink: true }
+                  }
+              }}
+            />
+          </LocalizationProvider>
+        );
+    case 'boolean':
+      return (
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={Boolean(value === undefined && field.defaultValue !== undefined ? field.defaultValue : value)}
+              onChange={(e) => onChange(field.name, e.target.checked)}
+              name={field.name}
+              disabled={disabled || field.readonly}
+            />
+          }
+          label={field.label}
+        />
+      );
+    case 'choice_single':
+      return (
+        <FormControl fullWidth error={Boolean(error)} disabled={disabled || field.readonly}>
+          <InputLabel id={`${field.name}-select-label`}>{field.label}{field.required ? ' *' : ''}</InputLabel>
+          <Select
+            labelId={`${field.name}-select-label`}
+            name={field.name}
+            value={value || field.defaultValue || ''}
+            label={field.label} // Label prop for Select for proper positioning
+            onChange={(e: SelectChangeEvent<string | number>) => onChange(field.name, e.target.value)}
+          >
+            <MenuItem value=""><em>None</em></MenuItem>
+            {field.options?.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+          {(error || field.helpText) && <FormHelperText>{error || field.helpText}</FormHelperText>}
+        </FormControl>
+      );
+    case 'choice_multiple':
+        // MUI Select with multiple attribute or CheckboxGroup
+        // This is a simplified version for now, a CheckboxGroup or Autocomplete might be better.
+        return (
+            <FormControl fullWidth error={Boolean(error)} disabled={disabled || field.readonly}>
+              <InputLabel id={`${field.name}-multi-select-label`}>{field.label}{field.required ? ' *' : ''}</InputLabel>
+              <Select
+                multiple
+                labelId={`${field.name}-multi-select-label`}
+                name={field.name}
+                value={Array.isArray(value) ? value : (field.defaultValue && Array.isArray(field.defaultValue) ? field.defaultValue : [])}
+                label={field.label}
+                onChange={(e: SelectChangeEvent<(string | number)[]>) => onChange(field.name, e.target.value as (string|number)[])}
+                renderValue={(selected) => {
+                    if (!Array.isArray(selected) || selected.length === 0) return '';
+                    return (selected as (string|number)[]).map(val => field.options?.find(opt => opt.value === val)?.label || val).join(', ');
+                }}
+              >
+                {field.options?.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    <Checkbox checked={Array.isArray(value) ? value.indexOf(option.value) > -1 : false} />
+                    <ListItemText primary={option.label} />
+                  </MenuItem>
+                ))}
+              </Select>
+              {(error || field.helpText) && <FormHelperText>{error || field.helpText}</FormHelperText>}
+            </FormControl>
+          );
+
+    // Placeholder for selector types - initially simple text inputs for IDs
+    case 'user_selector_single':
+    case 'user_selector_multiple':
+    case 'group_selector_single':
+    case 'group_selector_multiple':
+    case 'asset_selector_single':
+    case 'asset_selector_multiple':
+    case 'department_selector': // Assuming single selection for these
+    case 'project_selector':
+      return (
+        <TextField
+          {...commonProps}
+          type={field.type.includes('multiple') ? 'text' : "number"} // Text for multiple IDs (comma-sep), number for single
+          value={value || field.defaultValue || ''}
+          placeholder={field.placeholder || (field.type.includes('multiple') ? 'Enter IDs comma-separated' : 'Enter ID')}
+          onChange={(e) => onChange(field.name, field.type.includes('multiple') ? e.target.value.split(',').map(s => s.trim()).filter(Boolean) : (e.target.value === '' ? null : Number(e.target.value)))}
+          helperText={error || field.helpText || `Placeholder for ${field.label}. API source: ${field.api_source?.endpoint || 'N/A'}`}
+        />
+      );
+    case 'file_upload':
+        // Basic file input. Real implementation needs state in parent form for the File object.
+        // This renderer would just display the input type="file".
+        // For now, just a text field to input a filename or path as a string.
+        return (
+            <TextField
+                {...commonProps}
+                type="text"
+                value={value || field.defaultValue || ''} // Or handle File object if parent supports
+                placeholder={field.placeholder || "Enter file name or path (actual upload handled by form)"}
+                onChange={(e) => onChange(field.name, e.target.value)}
+                helperText={error || field.helpText || "File upload field. Actual upload mechanism is part of the main form."}
+                InputProps={{
+                    endAdornment: <InputAdornment position="end">(File)</InputAdornment>
+                }}
+            />
+        );
+
+    default:
+      return (
+        <Box sx={{p:1, border: '1px dashed red'}}>
+            <Typography color="error">Unsupported field type: {field.type} for field "{field.name}"</Typography>
+        </Box>
+      );
+  }
+};
+
+export default DynamicIomFormFieldRenderer;

--- a/itsm_frontend/src/modules/genericIom/components/GenericIomDetailComponent.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/GenericIomDetailComponent.tsx
@@ -1,0 +1,293 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  Grid,
+  CircularProgress,
+  Alert,
+  Button,
+  Divider,
+  Chip,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemIcon,
+  TextField, // For comments in actions
+} from '@mui/material';
+import DescriptionIcon from '@mui/icons-material/Description';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import GroupIcon from '@mui/icons-material/Group';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import SubjectIcon from '@mui/icons-material/Subject';
+import LabelIcon from '@mui/icons-material/Label';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import HighlightOffIcon from '@mui/icons-material/HighlightOff';
+import PublishIcon from '@mui/icons-material/Publish';
+import SendIcon from '@mui/icons-material/Send'; // For submit for approval
+
+import { useAuth } from '../../../context/auth/useAuth';
+import { useUI } from '../../../context/UIContext/useUI';
+import {
+    getGenericIomById,
+    submitGenericIomForSimpleApproval,
+    simpleApproveGenericIom,
+    simpleRejectGenericIom,
+    publishGenericIom
+} from '../../../api/genericIomApi';
+import type { GenericIOM, GenericIomSimpleActionPayload } from '../types/genericIomTypes';
+import type { FieldDefinition } from '../../iomTemplateAdmin/types/iomTemplateAdminTypes';
+// TODO: Import types and API function for ApprovalSteps
+
+interface GenericIomDetailComponentProps {
+  iomId: number;
+}
+
+// Helper to display dynamic field values appropriately
+const DisplayDynamicFieldValue: React.FC<{field: FieldDefinition, value: any}> = ({ field, value }) => {
+    if (value === null || value === undefined || String(value).trim() === '') {
+        return <Typography variant="body2" color="textSecondary"><em>Not provided</em></Typography>;
+    }
+    if (field.type === 'boolean') {
+        return <Chip label={value ? 'Yes' : 'No'} size="small" />;
+    }
+    if (field.type === 'date' && typeof value === 'string') {
+        return <Typography variant="body2">{new Date(value).toLocaleDateString()}</Typography>;
+    }
+    if (field.type === 'datetime' && typeof value === 'string') {
+        return <Typography variant="body2">{new Date(value).toLocaleString()}</Typography>;
+    }
+    if (Array.isArray(value)) {
+        return <Typography variant="body2">{value.join(', ')}</Typography>;
+    }
+    // TODO: Handle selector types by fetching related object names if IDs are stored
+    return <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap'}}>{String(value)}</Typography>;
+};
+
+
+const GenericIomDetailComponent: React.FC<GenericIomDetailComponentProps> = ({ iomId }) => {
+  const { authenticatedFetch, user } = useAuth();
+  const { showSnackbar, showConfirmDialog } = useUI();
+
+  const [iom, setIom] = useState<GenericIOM | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string|null>(null);
+  const [isActionLoading, setIsActionLoading] = useState<boolean>(false);
+  const [comments, setComments] = useState<string>(''); // For simple approve/reject actions
+
+  const fetchIomDetails = useCallback(async () => {
+    if (!authenticatedFetch || !iomId) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const fetchedIom = await getGenericIomById(authenticatedFetch, iomId);
+      setIom(fetchedIom);
+      // TODO: If approval_type is 'advanced', fetch approval steps here
+      // e.g., const steps = await getApprovalStepsForIom(authenticatedFetch, 'generic_iom', iomId);
+      // setApprovalSteps(steps);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "An unknown error occurred";
+      setError(`Failed to load IOM details: ${message}`);
+      showSnackbar(`Error: ${message}`, 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [authenticatedFetch, iomId, showSnackbar]);
+
+  useEffect(() => {
+    fetchIomDetails();
+  }, [fetchIomDetails]);
+
+  const handleAction = async (actionType: 'submit' | 'approve' | 'reject' | 'publish') => {
+    if (!iom || !authenticatedFetch) return;
+
+    setIsActionLoading(true);
+    setActionError(null);
+    setComments(''); // Reset comments for next action
+
+    const actionPayload: GenericIomSimpleActionPayload = { comments };
+
+    try {
+      let updatedIom: GenericIOM | null = null;
+      let successMessage = '';
+
+      if (actionType === 'submit') {
+        updatedIom = await submitGenericIomForSimpleApproval(authenticatedFetch, iom.id);
+        successMessage = "IOM submitted for simple approval.";
+      } else if (actionType === 'approve') {
+        if (iom.iom_template_details?.approval_type === 'simple') {
+            updatedIom = await simpleApproveGenericIom(authenticatedFetch, iom.id, actionPayload);
+            successMessage = "IOM simple-approved.";
+        }
+      } else if (actionType === 'reject') {
+        if (!comments.trim() && iom.iom_template_details?.approval_type === 'simple') {
+            showSnackbar("Comments are required for rejection.", "warning");
+            setActionError("Comments are required for rejection.");
+            setIsActionLoading(false);
+            return;
+        }
+        if (iom.iom_template_details?.approval_type === 'simple') {
+            updatedIom = await simpleRejectGenericIom(authenticatedFetch, iom.id, actionPayload);
+            successMessage = "IOM simple-rejected.";
+        }
+      } else if (actionType === 'publish') {
+        updatedIom = await publishGenericIom(authenticatedFetch, iom.id);
+        successMessage = "IOM published successfully.";
+      }
+
+      if (updatedIom) {
+        setIom(updatedIom); // Refresh IOM data
+        showSnackbar(successMessage, 'success');
+      }
+    } catch (err: any) {
+      const errorData = err?.data || err;
+      let errorMessage = `Failed to ${actionType} IOM.`;
+      if (typeof errorData === 'object' && errorData !== null) {
+        errorMessage = Object.values(errorData).flat().join(' ');
+      } else if (err instanceof Error) {
+        errorMessage = err.message;
+      } else if (typeof errorData === 'string'){
+        errorMessage = errorData;
+      }
+      setActionError(errorMessage);
+      showSnackbar(errorMessage, 'error');
+    } finally {
+      setIsActionLoading(false);
+    }
+  };
+
+
+  if (isLoading) {
+    return <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}><CircularProgress /></Box>;
+  }
+
+  if (error) {
+    return <Alert severity="error" sx={{ m: 2 }}>{error}</Alert>;
+  }
+
+  if (!iom) {
+    return <Alert severity="warning" sx={{ m: 2 }}>IOM details not found.</Alert>;
+  }
+
+  const canSubmitForSimpleApproval = iom.status === 'draft' && iom.iom_template_details?.approval_type === 'simple';
+  const canPerformSimpleApprovalAction = iom.status === 'pending_approval' && iom.iom_template_details?.approval_type === 'simple' &&
+                                        (iom.iom_template_details?.simple_approval_user === user?.id ||
+                                         (user?.groups && iom.iom_template_details?.simple_approval_group && user.groups.includes(iom.iom_template_details.simple_approval_group)));
+  const canPublish = (iom.status === 'draft' && iom.iom_template_details?.approval_type === 'none') ||
+                     (iom.status === 'approved'); // Approved by simple or advanced workflow
+
+  return (
+    <Box>
+      <Grid container spacing={2} sx={{mb: 2}}>
+        <Grid item xs={12} md={6}>
+          <Typography variant="body1"><strong>IOM ID:</strong> {iom.gim_id}</Typography>
+          <Typography variant="body1"><strong>Template:</strong> {iom.iom_template_details?.name || iom.iom_template}</Typography>
+          <Typography variant="body1"><strong>Status:</strong> <Chip label={iom.status_display || iom.status} color={iom.status === 'published' ? 'success' : 'default'} size="small" /></Typography>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Typography variant="body1"><strong>Created By:</strong> {iom.created_by_username || 'N/A'}</Typography>
+          <Typography variant="body1"><strong>Created At:</strong> {new Date(iom.created_at).toLocaleString()}</Typography>
+          {iom.published_at && <Typography variant="body1"><strong>Published At:</strong> {new Date(iom.published_at).toLocaleString()}</Typography>}
+        </Grid>
+      </Grid>
+
+      <Divider sx={{my:2}} />
+
+      <Typography variant="h6" gutterBottom>Subject: {iom.subject}</Typography>
+
+      {iom.to_users_details && iom.to_users_details.length > 0 && (
+        <Box sx={{mb:1}}>
+          <Typography variant="subtitle2" component="span"><strong>To Users: </strong></Typography>
+          {iom.to_users_details.map(u => u.username || u.id).join(', ')}
+        </Box>
+      )}
+      {iom.to_groups_details && iom.to_groups_details.length > 0 && (
+         <Box sx={{mb:1}}>
+            <Typography variant="subtitle2" component="span"><strong>To Groups: </strong></Typography>
+            {iom.to_groups_details.map(g => g.name || g.id).join(', ')}
+        </Box>
+      )}
+       {iom.parent_record_display && (
+         <Box sx={{mb:1}}>
+            <Typography variant="subtitle2" component="span"><strong>Related To: </strong></Typography>
+            {iom.parent_record_display}
+        </Box>
+      )}
+
+
+      <Typography variant="h6" sx={{mt:3, mb:1}}>Details:</Typography>
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Grid container spacing={2}>
+          {iom.iom_template_details?.fields_definition.map((fieldDef) => (
+            <Grid item xs={12} md={fieldDef.type === 'text_area' ? 12 : 6} key={fieldDef.name}>
+              <Box>
+                <Typography variant="subtitle2" color="textSecondary">{fieldDef.label}:</Typography>
+                <DisplayDynamicFieldValue field={fieldDef} value={iom.data_payload[fieldDef.name]} />
+              </Box>
+            </Grid>
+          ))}
+          {Object.keys(iom.data_payload).length === 0 && (
+            <Grid item xs={12}><Typography>No details provided in payload.</Typography></Grid>
+          )}
+        </Grid>
+      </Paper>
+
+      {/* Workflow Actions Section */}
+      <Box sx={{ mt: 3, p:2, border: '1px solid lightgray', borderRadius: 1}}>
+        <Typography variant="h6" gutterBottom>Actions</Typography>
+        {actionError && <Alert severity="error" sx={{mb:1}}>{actionError}</Alert>}
+
+        {canSubmitForSimpleApproval && (
+            <Button onClick={() => handleAction('submit')} variant="contained" startIcon={<SendIcon />} sx={{mr:1}} disabled={isActionLoading}>
+                {isActionLoading ? <CircularProgress size={20}/> : "Submit for Simple Approval"}
+            </Button>
+        )}
+
+        {canPerformSimpleApproval && (
+            <Box sx={{display: 'flex', alignItems: 'flex-start', gap:1, mb:1}}>
+                <TextField
+                    label="Comments (for Approve/Reject)"
+                    value={comments}
+                    onChange={(e) => setComments(e.target.value)}
+                    multiline rows={2} size="small" sx={{flexGrow:1}}
+                    helperText={iom.status === 'pending_approval' && iom.iom_template_details?.approval_type === 'simple' && !comments.trim() ? "Comments required for rejection" : ""}
+                />
+                <Button onClick={() => handleAction('approve')} variant="outlined" color="success" startIcon={<CheckCircleOutlineIcon />} sx={{height: 'fit-content', mt: 'auto', mb:'auto'}} disabled={isActionLoading}>
+                    {isActionLoading ? <CircularProgress size={20}/> : "Simple Approve"}
+                </Button>
+                <Button onClick={() => handleAction('reject')} variant="outlined" color="error" startIcon={<HighlightOffIcon />} sx={{height: 'fit-content', mt: 'auto', mb:'auto'}} disabled={isActionLoading || (!comments.trim() && iom.status === 'pending_approval')}>
+                     {isActionLoading ? <CircularProgress size={20}/> : "Simple Reject"}
+                </Button>
+            </Box>
+        )}
+
+        {canPublish && (
+            <Button onClick={() => handleAction('publish')} variant="contained" color="primary" startIcon={<PublishIcon />} disabled={isActionLoading}>
+                {isActionLoading ? <CircularProgress size={20}/> : "Publish IOM"}
+            </Button>
+        )}
+
+        {!(canSubmitForSimpleApproval || canPerformSimpleApproval || canPublish) && (
+            <Typography color="textSecondary">No actions available for this IOM in its current state or based on your permissions.</Typography>
+        )}
+      </Box>
+
+      {/* Placeholder for Advanced Approval Steps Display */}
+      {iom.iom_template_details?.approval_type === 'advanced' && (
+        <Box sx={{mt:3}}>
+            <Typography variant="h6" gutterBottom>Advanced Approval Workflow</Typography>
+            <Typography color="textSecondary">
+                {/* TODO: Fetch and display ApprovalStep instances related to this IOM.
+                    This will require an API endpoint like /api/procurement/approval-steps/?content_type=<ct_id>&object_id=<iom_pk>
+                    and an ApprovalStepSerializer that handles the GFK.
+                */}
+                Advanced approval steps will be shown here. (Status: {iom.status})
+            </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default GenericIomDetailComponent;

--- a/itsm_frontend/src/modules/genericIom/components/GenericIomForm.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/GenericIomForm.tsx
@@ -1,0 +1,272 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  TextField,
+  Button,
+  Box,
+  Typography,
+  CircularProgress,
+  Alert,
+  Grid,
+  Paper,
+  // For GFK selectors later:
+  // FormControl, InputLabel, Select, MenuItem,
+} from '@mui/material';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+
+
+import { useAuth } from '../../../context/auth/useAuth';
+import { useUI } from '../../../context/UIContext/useUI';
+import { getIomTemplateById } from '../../../api/genericIomApi'; // For fetching template on create
+import { getGenericIomById, createGenericIom, updateGenericIom } from '../../../api/genericIomApi'; // For IOM CRUD
+import type { IOMTemplate, FieldDefinition } from '../../iomTemplateAdmin/types/iomTemplateAdminTypes';
+import type { GenericIOM, GenericIOMCreateData, GenericIOMUpdateData, IomDataPayload } from '../types/genericIomTypes';
+import DynamicIomFormFieldRenderer from './DynamicIomFormFieldRenderer'; // The dynamic renderer
+
+interface GenericIomFormProps {
+  // Props can be used if this form is embedded, but using useParams for page-level form
+}
+
+const GenericIomForm: React.FC<GenericIomFormProps> = () => {
+  const { templateId: templateIdParam, iomId: iomIdParam } = useParams<{ templateId?: string; iomId?: string }>();
+  const navigate = useNavigate();
+  const { authenticatedFetch } = useAuth();
+  const { showSnackbar } = useUI();
+
+  const [iomTemplate, setIomTemplate] = useState<IOMTemplate | null>(null);
+  const [initialDataPayload, setInitialDataPayload] = useState<IomDataPayload>({});
+
+  // Form state for standard fields
+  const [subject, setSubject] = useState<string>('');
+  const [toUsersStr, setToUsersStr] = useState<string>(''); // Comma-separated IDs
+  const [toGroupsStr, setToGroupsStr] = useState<string>(''); // Comma-separated IDs
+  // TODO: Add state for parent_content_type_id and parent_object_id
+
+  // Form state for dynamic data_payload fields
+  const [dynamicFormData, setDynamicFormData] = useState<IomDataPayload>({});
+
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isEditMode = Boolean(iomIdParam);
+  const templateId = isEditMode ? null : (templateIdParam ? parseInt(templateIdParam,10) : null);
+  const iomId = isEditMode ? (iomIdParam ? parseInt(iomIdParam,10) : null) : null;
+
+
+  const loadData = useCallback(async () => {
+    if (!authenticatedFetch) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      if (isEditMode && iomId) {
+        const fetchedIom = await getGenericIomById(authenticatedFetch, iomId);
+        if (!fetchedIom.iom_template_details) { // Ensure template details are fetched with IOM for edit
+            showSnackbar("IOM data is missing template details for editing.", "error");
+            setError("IOM data is missing template details for editing.");
+            setIsLoading(false);
+            return;
+        }
+        // Assuming iom_template_details contains the full template structure including fields_definition
+        const templateForEdit = fetchedIom.iom_template_details as unknown as IOMTemplate; // Cast if necessary
+        setIomTemplate(templateForEdit);
+        setSubject(fetchedIom.subject);
+        setDynamicFormData(fetchedIom.data_payload || {});
+        setInitialDataPayload(fetchedIom.data_payload || {});
+        setToUsersStr(fetchedIom.to_users?.join(',') || '');
+        setToGroupsStr(fetchedIom.to_groups?.join(',') || '');
+        // TODO: Set parent record fields
+      } else if (templateId) { // Create mode
+        const fetchedTemplate = await getIomTemplateById(authenticatedFetch, templateId);
+        setIomTemplate(fetchedTemplate);
+        // Initialize dynamicFormData with defaultValues from template
+        const initialPayload: IomDataPayload = {};
+        fetchedTemplate.fields_definition.forEach(field => {
+          if (field.defaultValue !== undefined) {
+            initialPayload[field.name] = field.defaultValue;
+          }
+        });
+        setDynamicFormData(initialPayload);
+        setInitialDataPayload(initialPayload);
+      } else {
+        setError("No Template ID provided for new IOM or IOM ID for editing.");
+        showSnackbar("Cannot load form: Missing Template or IOM ID.", "error");
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "An unknown error occurred";
+      setError(`Failed to load data: ${message}`);
+      showSnackbar(`Error: ${message}`, 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [authenticatedFetch, templateId, iomId, isEditMode, showSnackbar]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleDynamicFieldChange = (fieldName: string, value: any) => {
+    setDynamicFormData(prev => ({ ...prev, [fieldName]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!authenticatedFetch || !iomTemplate) {
+      setError("Form not ready or authentication error.");
+      return;
+    }
+
+    // Basic validation for subject
+    if (!subject.trim()) {
+        showSnackbar("Subject is required.", "warning");
+        setError("Subject is required.");
+        return;
+    }
+    // TODO: Add validation for required dynamic fields based on iomTemplate.fields_definition
+
+    setIsSubmitting(true);
+    setError(null);
+
+    const commonPayload = {
+        subject,
+        data_payload: dynamicFormData,
+        to_users: toUsersStr.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id) && id > 0),
+        to_groups: toGroupsStr.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id) && id > 0),
+        // TODO: Add parent_content_type_id, parent_object_id
+    };
+
+    try {
+      if (isEditMode && iomId) {
+        const updateData: GenericIOMUpdateData = commonPayload;
+        // Note: iom_template cannot be changed on update as per GenericIOMUpdateData definition
+        const updatedIom = await updateGenericIom(authenticatedFetch, iomId, updateData);
+        showSnackbar(`IOM "${updatedIom.subject}" updated successfully!`, 'success');
+        navigate(`/ioms/view/${updatedIom.id}`);
+      } else if (templateId) { // Create mode
+        const createData: GenericIOMCreateData = {
+          ...commonPayload,
+          iom_template: templateId, // Add templateId for creation
+        };
+        const newIom = await createGenericIom(authenticatedFetch, createData);
+        showSnackbar(`IOM "${newIom.subject}" created successfully!`, 'success');
+        navigate(`/ioms/view/${newIom.id}`); // Navigate to the new IOM's detail view
+      }
+    } catch (err: any) {
+      const errorData = err?.data || err;
+      let errorMessage = "Failed to save IOM.";
+      if (typeof errorData === 'object' && errorData !== null) {
+        const fieldErrors = Object.entries(errorData)
+            .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : String(value)}`)
+            .join('; ');
+        if (fieldErrors) errorMessage = `Validation Error: ${fieldErrors}`;
+      } else if (err instanceof Error) {
+        errorMessage = err.message;
+      } else if (typeof errorData === 'string') {
+        errorMessage = errorData;
+      }
+      setError(errorMessage);
+      showSnackbar(errorMessage, 'error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading) {
+    return <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}><CircularProgress /></Box>;
+  }
+
+  if (error && !isSubmitting) { // Show general error if not during submission attempt (already handled by loadData for initial load)
+    // This error state is more for submission errors that are not field-specific.
+    // return <Alert severity="error" sx={{m:2}}>{error}</Alert>;
+  }
+
+  if (!iomTemplate) {
+    return <Alert severity="warning" sx={{m:2}}>Template information could not be loaded. {error}</Alert>;
+  }
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Box component="form" onSubmit={handleSubmit} noValidate>
+        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+        <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <Typography variant="h6" gutterBottom>Template: {iomTemplate.name}</Typography>
+            {iomTemplate.description && <Typography variant="body2" color="textSecondary" gutterBottom>{iomTemplate.description}</Typography>}
+          </Grid>
+
+          <Grid item xs={12}>
+            <TextField
+              name="subject"
+              label="Subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              fullWidth
+              required
+              disabled={isSubmitting}
+            />
+          </Grid>
+
+          {/* Dynamic Fields Section */}
+          <Grid item xs={12}>
+            <Paper variant="outlined" sx={{p:2}}>
+                <Typography variant="subtitle1" gutterBottom>Details (based on template)</Typography>
+                <Grid container spacing={2}>
+                    {iomTemplate.fields_definition.map((fieldDef) => (
+                    <Grid item xs={12} md={fieldDef.type === 'text_area' ? 12 : (fieldDef.type === 'boolean' ? 12 : 6)} key={fieldDef.name}>
+                        <DynamicIomFormFieldRenderer
+                        field={fieldDef}
+                        value={dynamicFormData[fieldDef.name]}
+                        onChange={handleDynamicFieldChange}
+                        disabled={isSubmitting}
+                        // TODO: Pass field-specific errors if available from backend validation on data_payload
+                        />
+                    </Grid>
+                    ))}
+                </Grid>
+            </Paper>
+          </Grid>
+
+          {/* Standard Fields: Recipients, Parent Record - Simplified for now */}
+          <Grid item xs={12} md={6}>
+            <TextField
+                name="toUsersStr"
+                label="To Users (comma-separated IDs)"
+                value={toUsersStr}
+                onChange={(e) => setToUsersStr(e.target.value)}
+                fullWidth
+                disabled={isSubmitting}
+                helperText="Future: User selector component."
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <TextField
+                name="toGroupsStr"
+                label="To Groups (comma-separated IDs)"
+                value={toGroupsStr}
+                onChange={(e) => setToGroupsStr(e.target.value)}
+                fullWidth
+                disabled={isSubmitting}
+                helperText="Future: Group selector component."
+            />
+          </Grid>
+          {/* TODO: Add Parent Record GFK input fields (ContentType dropdown, ObjectID input) */}
+
+
+          <Grid item xs={12} sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end' }}>
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              disabled={isSubmitting || isLoading}
+            >
+              {isSubmitting ? <CircularProgress size={24} /> : (isEditMode ? 'Update IOM' : 'Create IOM')}
+            </Button>
+          </Grid>
+        </Grid>
+      </Box>
+    </LocalizationProvider>
+  );
+};
+
+export default GenericIomForm;

--- a/itsm_frontend/src/modules/genericIom/components/GenericIomList.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/GenericIomList.tsx
@@ -1,0 +1,289 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Paper,
+  IconButton,
+  Chip,
+  Tooltip,
+  TablePagination,
+  CircularProgress,
+  Alert,
+  TextField, // For filtering
+  MenuItem,
+  Select,
+  FormControl,
+  InputLabel,
+  Grid,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import EditIcon from '@mui/icons-material/Edit';
+// import DeleteIcon from '@mui/icons-material/Delete'; // Optional: if delete action is added
+import { Link as RouterLink } from 'react-router-dom';
+
+import { useAuth } from '../../../context/auth/useAuth';
+import { useUI } from '../../../context/UIContext/useUI';
+import { getGenericIoms, getIomTemplates } from '../../../api/genericIomApi';
+import type { GenericIOM, GetGenericIomsParams, GenericIomStatus } from '../types/genericIomTypes';
+import type { IOMTemplate } from '../../iomTemplateAdmin/types/iomTemplateAdminTypes';
+
+type Order = 'asc' | 'desc';
+// Define keys for sorting, ensuring they match GenericIOM properties or backend ordering fields
+type OrderableGenericIomKey = 'gim_id' | 'subject' | 'iom_template__name' | 'status' | 'created_by__username' | 'created_at';
+
+
+interface HeadCell {
+  id: OrderableGenericIomKey | 'actions';
+  label: string;
+  numeric: boolean;
+  sortable: boolean;
+}
+
+const headCells: readonly HeadCell[] = [
+  { id: 'gim_id', label: 'IOM ID', numeric: false, sortable: true },
+  { id: 'subject', label: 'Subject', numeric: false, sortable: true },
+  { id: 'iom_template__name', label: 'Template', numeric: false, sortable: true },
+  { id: 'status', label: 'Status', numeric: false, sortable: true },
+  { id: 'created_by__username', label: 'Created By', numeric: false, sortable: true },
+  { id: 'created_at', label: 'Created At', numeric: false, sortable: true },
+  { id: 'actions', label: 'Actions', numeric: false, sortable: false },
+];
+
+const statusOptions: GenericIomStatus[] = ['draft', 'pending_approval', 'approved', 'rejected', 'published', 'archived', 'cancelled'];
+
+
+const GenericIomListComponent: React.FC = () => {
+  const { authenticatedFetch, user } = useAuth();
+  const { showSnackbar } = useUI(); // showConfirmDialog if delete is added
+
+  const [ioms, setIoms] = useState<GenericIOM[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [totalIoms, setTotalIoms] = useState<number>(0);
+  const [page, setPage] = useState<number>(0);
+  const [rowsPerPage, setRowsPerPage] = useState<number>(10);
+
+  const [order, setOrder] = useState<Order>('desc');
+  const [orderBy, setOrderBy] = useState<OrderableGenericIomKey>('created_at');
+
+  // Filters
+  const [templatesForFilter, setTemplatesForFilter] = useState<IOMTemplate[]>([]);
+  const [filterSubject, setFilterSubject] = useState<string>('');
+  const [filterStatus, setFilterStatus] = useState<GenericIomStatus | ''>('');
+  const [filterTemplateId, setFilterTemplateId] = useState<string>('');
+
+
+  const fetchIoms = useCallback(async () => {
+    if (!authenticatedFetch) return;
+    setIsLoading(true);
+    setError(null);
+
+    const params: GetGenericIomsParams = {
+      page: page + 1,
+      pageSize: rowsPerPage,
+      ordering: `${order === 'desc' ? '-' : ''}${orderBy}`,
+      search: filterSubject || undefined, // Backend search for subject/gim_id/etc.
+      status: filterStatus || undefined,
+      iom_template_id: filterTemplateId ? parseInt(filterTemplateId) : undefined,
+    };
+
+    try {
+      const response = await getGenericIoms(authenticatedFetch, params);
+      setIoms(response.results);
+      setTotalIoms(response.count);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message || 'Failed to fetch IOMs.');
+      showSnackbar(`Error fetching IOMs: ${message}`, 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [authenticatedFetch, page, rowsPerPage, order, orderBy, filterSubject, filterStatus, filterTemplateId, showSnackbar]);
+
+  const fetchTemplatesForFilterDropdown = useCallback(async () => {
+    if(!authenticatedFetch) return;
+    try {
+        const response = await getIomTemplates(authenticatedFetch, { is_active: true, pageSize: 500});
+        setTemplatesForFilter(response.results);
+    } catch (err) {
+        console.error("Failed to fetch templates for filter:", err);
+        showSnackbar("Could not load templates for filtering.", "error");
+    }
+  }, [authenticatedFetch, showSnackbar]);
+
+
+  useEffect(() => {
+    fetchIoms();
+  }, [fetchIoms]);
+
+  useEffect(() => {
+    fetchTemplatesForFilterDropdown();
+  }, [fetchTemplatesForFilterDropdown]);
+
+
+  const handleRequestSort = (property: OrderableGenericIomKey) => {
+    const isAsc = orderBy === property && order === 'asc';
+    setOrder(isAsc ? 'desc' : 'asc');
+    setOrderBy(property);
+  };
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const getStatusChipColor = (status: GenericIomStatus) => {
+    switch (status) {
+      case 'draft': return 'default';
+      case 'pending_approval': return 'warning';
+      case 'approved': return 'info'; // Different from PRM 'approved'
+      case 'published': return 'success';
+      case 'rejected': return 'error';
+      case 'cancelled': return 'default';
+      case 'archived': return 'secondary';
+      default: return 'default';
+    }
+  };
+
+  // TODO: Add handleDelete if needed, similar to IomTemplateList
+
+  return (
+    <Paper sx={{ width: '100%', mb: 2 }} elevation={2}>
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6" gutterBottom>Filter IOMs</Typography>
+        <Grid container spacing={2} alignItems="center">
+          <Grid item xs={12} sm={4}>
+            <TextField
+              fullWidth
+              label="Search by Subject/ID"
+              variant="outlined"
+              value={filterSubject}
+              onChange={(e) => setFilterSubject(e.target.value)}
+              size="small"
+            />
+          </Grid>
+          <Grid item xs={12} sm={4}>
+            <FormControl fullWidth size="small">
+              <InputLabel id="status-filter-label">Status</InputLabel>
+              <Select
+                labelId="status-filter-label"
+                value={filterStatus}
+                label="Status"
+                onChange={(e: SelectChangeEvent<GenericIomStatus | ''>) => setFilterStatus(e.target.value as GenericIomStatus | '')}
+              >
+                <MenuItem value=""><em>All Statuses</em></MenuItem>
+                {statusOptions.map(s => <MenuItem key={s} value={s}>{s.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</MenuItem>)}
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12} sm={4}>
+            <FormControl fullWidth size="small">
+              <InputLabel id="template-filter-label">Template</InputLabel>
+              <Select
+                labelId="template-filter-label"
+                value={filterTemplateId}
+                label="Template"
+                onChange={(e: SelectChangeEvent<string>) => setFilterTemplateId(e.target.value)}
+              >
+                <MenuItem value=""><em>All Templates</em></MenuItem>
+                {templatesForFilter.map(t => <MenuItem key={t.id} value={String(t.id)}>{t.name}</MenuItem>)}
+              </Select>
+            </FormControl>
+          </Grid>
+          {/* Button to apply filters or auto-apply on change (currently auto-applies via useEffect dependency on fetchIoms) */}
+        </Grid>
+      </Box>
+      <TableContainer>
+        <Table aria-labelledby="genericIomTable" size="medium">
+          <TableHead>
+            <TableRow>
+              {headCells.map((headCell) => (
+                <TableCell
+                  key={headCell.id}
+                  align={headCell.numeric ? 'right' : 'left'}
+                  padding="normal"
+                  sortDirection={orderBy === headCell.id ? order : false}
+                >
+                  {headCell.sortable ? (
+                    <TableSortLabel
+                      active={orderBy === headCell.id}
+                      direction={orderBy === headCell.id ? order : 'asc'}
+                      onClick={() => handleRequestSort(headCell.id as OrderableGenericIomKey)}
+                    >
+                      {headCell.label}
+                    </TableSortLabel>
+                  ) : (
+                    headCell.label
+                  )}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {isLoading && ioms.length === 0 ? (
+              <TableRow><TableCell colSpan={headCells.length} align="center"><CircularProgress /></TableCell></TableRow>
+            ) : ioms.length === 0 && !isLoading ? (
+              <TableRow><TableCell colSpan={headCells.length} align="center">No IOMs found.</TableCell></TableRow>
+            ) : (
+              ioms.map((iom) => (
+                <TableRow hover tabIndex={-1} key={iom.id}>
+                  <TableCell>{iom.gim_id || iom.id}</TableCell>
+                  <TableCell>{iom.subject}</TableCell>
+                  <TableCell>{iom.iom_template_details?.name || iom.iom_template}</TableCell>
+                  <TableCell>
+                    <Chip
+                        label={iom.status_display || iom.status.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}
+                        color={getStatusChipColor(iom.status)}
+                        size="small"
+                    />
+                  </TableCell>
+                  <TableCell>{iom.created_by_username || 'N/A'}</TableCell>
+                  <TableCell>{new Date(iom.created_at).toLocaleDateString()}</TableCell>
+                  <TableCell>
+                    <Tooltip title="View IOM">
+                      <IconButton component={RouterLink} to={`/ioms/view/${iom.id}`} size="small">
+                        <VisibilityIcon />
+                      </IconButton>
+                    </Tooltip>
+                    { (iom.status === 'draft' && iom.created_by === user?.id) || user?.is_staff ? ( // Example edit condition
+                      <Tooltip title="Edit IOM">
+                        <IconButton component={RouterLink} to={`/ioms/edit/${iom.id}`} size="small">
+                          <EditIcon />
+                        </IconButton>
+                      </Tooltip>
+                    ) : null}
+                    {/* TODO: Add other actions like Publish, Submit for Approval, etc. based on status and permissions */}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination
+        rowsPerPageOptions={[5, 10, 25, 50]}
+        component="div"
+        count={totalIoms}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+      />
+    </Paper>
+  );
+};
+
+export default GenericIomListComponent;

--- a/itsm_frontend/src/modules/genericIom/components/SelectIomTemplateComponent.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/SelectIomTemplateComponent.tsx
@@ -1,0 +1,180 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  ListItemIcon,
+  CircularProgress,
+  Alert,
+  TextField,
+  InputAdornment,
+  Paper,
+  Collapse,
+  IconButton,
+} from '@mui/material';
+import DescriptionIcon from '@mui/icons-material/Description'; // For templates
+import CategoryIcon from '@mui/icons-material/Category'; // For categories
+import SearchIcon from '@mui/icons-material/Search';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import { useNavigate } from 'react-router-dom';
+
+import { useAuth } from '../../../context/auth/useAuth';
+import { useUI } from '../../../context/UIContext/useUI';
+import { getIomTemplates } from '../../../api/genericIomApi';
+import type { IOMTemplate, IOMCategory } from '../../iomTemplateAdmin/types/iomTemplateAdminTypes'; // Using admin types for now
+
+interface GroupedTemplates {
+  [categoryName: string]: IOMTemplate[];
+}
+
+const SelectIomTemplateComponent: React.FC = () => {
+  const { authenticatedFetch } = useAuth();
+  const navigate = useNavigate();
+  const { showSnackbar } = useUI();
+
+  const [templates, setTemplates] = useState<IOMTemplate[]>([]);
+  const [groupedTemplates, setGroupedTemplates] = useState<GroupedTemplates>({});
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [openCategories, setOpenCategories] = useState<Record<string, boolean>>({});
+
+  const fetchAndGroupTemplates = useCallback(async () => {
+    if (!authenticatedFetch) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      // Fetch only active templates for users to select from
+      const response = await getIomTemplates(authenticatedFetch, { is_active: true, pageSize: 500 }); // Fetch many
+      setTemplates(response.results);
+
+      const grouped: GroupedTemplates = {};
+      response.results.forEach(template => {
+        const categoryName = template.category_name || 'Uncategorized';
+        if (!grouped[categoryName]) {
+          grouped[categoryName] = [];
+        }
+        grouped[categoryName].push(template);
+      });
+      setGroupedTemplates(grouped);
+      // Initially open all categories
+      const initialOpenState: Record<string, boolean> = {};
+      Object.keys(grouped).forEach(catName => initialOpenState[catName] = true);
+      setOpenCategories(initialOpenState);
+
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message || 'Failed to fetch IOM templates.');
+      showSnackbar(`Error fetching templates: ${message}`, 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [authenticatedFetch, showSnackbar]);
+
+  useEffect(() => {
+    fetchAndGroupTemplates();
+  }, [fetchAndGroupTemplates]);
+
+  const handleTemplateSelect = (templateId: number) => {
+    navigate(`/ioms/new/${templateId}`);
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value.toLowerCase());
+  };
+
+  const toggleCategory = (categoryName: string) => {
+    setOpenCategories(prev => ({ ...prev, [categoryName]: !prev[categoryName] }));
+  };
+
+  const filteredGroupedTemplates = Object.entries(groupedTemplates).reduce((acc, [categoryName, templatesInCategory]) => {
+    const filteredTemplates = templatesInCategory.filter(template =>
+      template.name.toLowerCase().includes(searchTerm) ||
+      (template.description && template.description.toLowerCase().includes(searchTerm))
+    );
+    if (filteredTemplates.length > 0) {
+      acc[categoryName] = filteredTemplates;
+    }
+    return acc;
+  }, {} as GroupedTemplates);
+
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', p: 3 }}>
+        <CircularProgress />
+        <Typography sx={{ ml: 2 }}>Loading templates...</Typography>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error" sx={{ m: 2 }}>{error}</Alert>;
+  }
+
+  const categoryOrder = Object.keys(filteredGroupedTemplates).sort((a,b) => a === 'Uncategorized' ? 1 : b === 'Uncategorized' ? -1 : a.localeCompare(b));
+
+
+  return (
+    <Box>
+      <TextField
+        fullWidth
+        variant="outlined"
+        placeholder="Search templates by name or description..."
+        value={searchTerm}
+        onChange={handleSearchChange}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          ),
+        }}
+        sx={{ mb: 2 }}
+      />
+
+      {categoryOrder.length === 0 && !isLoading && (
+        <Typography>No templates found matching your criteria.</Typography>
+      )}
+
+      <List component="nav" aria-labelledby="nested-list-subheader">
+        {categoryOrder.map((categoryName) => (
+          <React.Fragment key={categoryName}>
+            <ListItemButton onClick={() => toggleCategory(categoryName)} sx={{backgroundColor: 'action.hover', borderRadius:1, mb:0.5}}>
+              <ListItemIcon>
+                <CategoryIcon />
+              </ListItemIcon>
+              <ListItemText primary={<Typography variant="h6">{categoryName}</Typography>} />
+              {openCategories[categoryName] ? <ExpandLess /> : <ExpandMore />}
+            </ListItemButton>
+            <Collapse in={openCategories[categoryName]} timeout="auto" unmountOnExit>
+              <List component="div" disablePadding sx={{ pl: 2 }}>
+                {filteredGroupedTemplates[categoryName].map((template) => (
+                  <ListItemButton
+                    key={template.id}
+                    onClick={() => handleTemplateSelect(template.id)}
+                    sx={{borderBottom: '1px solid #eee', '&:last-child': { borderBottom: 0}}}
+                  >
+                    <ListItemIcon>
+                      <DescriptionIcon />
+                    </ListItemIcon>
+                    <ListItemText
+                        primary={template.name}
+                        secondary={template.description || 'No description available.'}
+                    />
+                  </ListItemButton>
+                ))}
+              </List>
+            </Collapse>
+          </React.Fragment>
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default SelectIomTemplateComponent;

--- a/itsm_frontend/src/modules/genericIom/pages/.gitkeep
+++ b/itsm_frontend/src/modules/genericIom/pages/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to create the 'pages' directory

--- a/itsm_frontend/src/modules/genericIom/pages/GenericIomDetailPage.tsx
+++ b/itsm_frontend/src/modules/genericIom/pages/GenericIomDetailPage.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Box, Typography, Paper, Button, CircularProgress, Alert } from '@mui/material';
+import { useParams, useNavigate } from 'react-router-dom';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import EditIcon from '@mui/icons-material/Edit'; // Keep EditIcon if needed for a page-level button
+import { Link as RouterLink } from 'react-router-dom'; // For Edit button link
+
+import GenericIomDetailComponent from '../components/GenericIomDetailComponent'; // Import the actual component
+
+const GenericIomDetailPage: React.FC = () => {
+  const { iomId } = useParams<{ iomId?: string }>();
+  const navigate = useNavigate();
+
+  // The GenericIomDetailComponent will handle its own data fetching, loading, and error states.
+  // This page component primarily provides the overall page structure and title.
+
+  if (!iomId) {
+    return (
+      <Paper sx={{ p: { xs: 2, md: 4 }, m: { xs: 1, md: 2 } }} elevation={3}>
+        <Button variant="outlined" startIcon={<ArrowBackIcon />} onClick={() => navigate('/ioms')}>
+          Back to IOMs
+        </Button>
+        <Alert severity="error" sx={{ mt: 2 }}>Invalid IOM ID provided.</Alert>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper sx={{ p: { xs: 2, md: 4 }, m: { xs: 1, md: 2 } }} elevation={3}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Button variant="outlined" startIcon={<ArrowBackIcon />} onClick={() => navigate('/ioms')}>
+            Back to IOMs
+          </Button>
+          {/* Title can be dynamic based on fetched IOM data, or more generic here */}
+          <Typography variant="h5" component="h1">
+            IOM Details
+          </Typography>
+        </Box>
+        {/* Edit button can live here, or within the DetailComponent based on permissions fetched with IOM */}
+        <Button
+            variant="contained"
+            color="primary"
+            component={RouterLink}
+            to={`/ioms/edit/${iomId}`}
+            startIcon={<EditIcon />}
+            // Add logic here or in DetailComponent to disable if not editable by current user
+        >
+            Edit IOM
+        </Button>
+      </Box>
+
+      <GenericIomDetailComponent iomId={parseInt(iomId, 10)} />
+
+    </Paper>
+  );
+};
+
+export default GenericIomDetailPage;

--- a/itsm_frontend/src/modules/genericIom/pages/GenericIomFormPage.tsx
+++ b/itsm_frontend/src/modules/genericIom/pages/GenericIomFormPage.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Box, Typography, Paper, Button } from '@mui/material';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+
+import GenericIomFormComponent from '../components/GenericIomForm'; // Import the actual form component
+
+const GenericIomFormPage: React.FC = () => {
+  const { templateId, iomId } = useParams<{ templateId?: string; iomId?: string }>();
+  const navigate = useNavigate();
+  // const location = useLocation(); // Not needed if form component handles its own data fetching via params
+
+  const isEditMode = Boolean(iomId);
+  // The GenericIomFormComponent will fetch template details if needed, so page title can be more generic here
+  // or the form component could provide title information via a context or callback if desired.
+  const pageTitle = isEditMode
+    ? 'Edit Internal Office Memo'
+    : 'Create New Internal Office Memo';
+
+  return (
+    <Paper sx={{ p: { xs: 2, md: 4 }, m: { xs: 1, md: 2 } }} elevation={3}>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 3, gap: 2 }}>
+        <Button
+          variant="outlined"
+          startIcon={<ArrowBackIcon />}
+          // Navigate back to IOM list, or to detail view if editing, or to template selection if creating from specific template route
+          onClick={() => navigate(isEditMode ? `/ioms/view/${iomId}` : (templateId ? '/ioms/new/select-template' : '/ioms') )}
+        >
+          {isEditMode ? 'Back to View' : (templateId ? 'Back to Template Selection': 'Back to IOMs')}
+        </Button>
+        <Typography variant="h5" component="h1">
+          {pageTitle}
+        </Typography>
+      </Box>
+      <GenericIomFormComponent /> {/* Render the actual form component */}
+      {/* The GenericIomFormComponent uses useParams internally to get templateId or iomId */}
+    </Paper>
+  );
+};
+
+export default GenericIomFormPage;

--- a/itsm_frontend/src/modules/genericIom/pages/GenericIomListPage.tsx
+++ b/itsm_frontend/src/modules/genericIom/pages/GenericIomListPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Box, Typography, Button } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import AddIcon from '@mui/icons-material/Add';
+
+import GenericIomListComponent from '../components/GenericIomList'; // Import the actual list component
+
+const GenericIomListPage: React.FC = () => {
+  return (
+    <Box sx={{ p: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Typography variant="h4" component="h1">
+          Internal Office Memos (IOMs)
+        </Typography>
+        <Button
+          variant="contained"
+          component={RouterLink}
+          to="/ioms/new/select-template" // Route to select a template first
+          startIcon={<AddIcon />}
+        >
+          Create New IOM
+        </Button>
+      </Box>
+      <GenericIomListComponent /> {/* Use the actual list component */}
+    </Box>
+  );
+};
+
+export default GenericIomListPage;

--- a/itsm_frontend/src/modules/genericIom/pages/SelectIomTemplatePage.tsx
+++ b/itsm_frontend/src/modules/genericIom/pages/SelectIomTemplatePage.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Box, Typography, Button, Paper } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+
+import SelectIomTemplateComponent from '../components/SelectIomTemplateComponent'; // Import the actual component
+
+const SelectIomTemplatePage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Paper sx={{ p: { xs: 2, md: 4 }, m: { xs: 1, md: 2 } }} elevation={3}>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 3, gap: 2 }}>
+        <Button
+          variant="outlined"
+          startIcon={<ArrowBackIcon />}
+          onClick={() => navigate('/ioms')} // Navigate back to IOM list
+        >
+          Back to IOMs
+        </Button>
+        <Typography variant="h5" component="h1">
+          Create New IOM: Select Template
+        </Typography>
+      </Box>
+      <SelectIomTemplateComponent /> {/* Use the actual component */}
+    </Paper>
+  );
+};
+
+export default SelectIomTemplatePage;

--- a/itsm_frontend/src/modules/genericIom/types/.gitkeep
+++ b/itsm_frontend/src/modules/genericIom/types/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to create the 'types' directory

--- a/itsm_frontend/src/modules/genericIom/types/genericIomTypes.ts
+++ b/itsm_frontend/src/modules/genericIom/types/genericIomTypes.ts
@@ -1,0 +1,92 @@
+// Defines types related to Generic IOM instances for the frontend.
+
+// Assuming PaginatedResponse and AuthenticatedFetch types are globally available
+// or imported into genericIomApi.ts from a shared location.
+
+import type { IOMTemplate } from '../../iomTemplateAdmin/types/iomTemplateAdminTypes'; // For nesting template details
+
+// Status choices for GenericIOM - should align with backend model
+export type GenericIomStatus =
+  | 'draft'
+  | 'pending_approval'
+  | 'approved'
+  | 'rejected'
+  | 'published'
+  | 'archived'
+  | 'cancelled';
+
+// Structure for the data_payload - can be any JSON object
+export type IomDataPayload = Record<string, any>; // Or Record<string, unknown> for stricter typing
+
+// Interface for a GenericIOM object received from the API
+export interface GenericIOM {
+  id: number;
+  gim_id: string | null; // System-generated ID
+  iom_template: number; // ID of the IOMTemplate
+  iom_template_details?: Pick<IOMTemplate, 'id' | 'name' | 'fields_definition' | 'approval_type'>; // Expanded details
+  subject: string;
+  data_payload: IomDataPayload;
+  status: GenericIomStatus;
+  status_display?: string; // Read-only from backend
+  created_by: number; // User ID
+  created_by_username?: string | null;
+  created_at: string; // ISO date string
+  updated_at: string; // ISO date string
+  published_at?: string | null; // ISO date string
+
+  to_users: number[]; // Array of user IDs
+  to_users_details?: Array<{ id: number; username: string; first_name?: string; last_name?: string }>;
+  to_groups: number[]; // Array of group IDs
+  to_groups_details?: Array<{ id: number; name: string }>;
+
+  parent_content_type?: number | null; // ContentType ID
+  parent_content_type_name?: string | null; // e.g., "asset", "project"
+  parent_object_id?: number | null;
+  parent_record_display?: string | null; // User-friendly display of the parent record
+
+  // Fields for simple approval tracking
+  simple_approver_action_by?: number | null; // User ID
+  simple_approver_action_by_username?: string | null;
+  simple_approval_action_at?: string | null; // ISO date string
+  simple_approval_comments?: string | null;
+
+  // Placeholder for advanced approval steps if fetched/nested
+  // approval_steps?: any[];
+}
+
+// Data for creating a new GenericIOM
+export interface GenericIOMCreateData {
+  iom_template: number; // ID of the IOMTemplate
+  subject: string;
+  data_payload: IomDataPayload;
+  to_users?: number[];
+  to_groups?: number[];
+  parent_content_type_id?: number | null; // For GFK write
+  parent_object_id?: number | null;     // For GFK write
+  status?: GenericIomStatus; // Optional: backend might default to 'draft'
+}
+
+// Data for updating an existing GenericIOM (most fields optional)
+export type GenericIOMUpdateData = Partial<Omit<GenericIOMCreateData, 'iom_template'>>; // Template usually not changed after creation
+
+
+// Params for fetching GenericIOM list
+export interface GetGenericIomsParams {
+  page?: number;
+  pageSize?: number;
+  ordering?: string;
+  status?: GenericIomStatus | GenericIomStatus[];
+  iom_template_id?: number;
+  created_by_id?: number;
+  search?: string; // For searching subject, gim_id, data_payload content
+  // Add other potential filter params like date ranges
+}
+
+// --- Payloads for Custom Actions ---
+
+export interface GenericIomSimpleActionPayload {
+  comments?: string;
+}
+
+// GenericIOMPublishPayload might not be needed if it's just an action without data
+// export interface GenericIOMPublishPayload {}

--- a/itsm_frontend/src/pages/HomePage.tsx
+++ b/itsm_frontend/src/pages/HomePage.tsx
@@ -32,6 +32,7 @@ import AccountCircle from '@mui/icons-material/AccountCircle';
 import CategoryIcon from '@mui/icons-material/Category';
 import PlaylistAddCheckIcon from '@mui/icons-material/PlaylistAddCheck';
 import ListAltIcon from '@mui/icons-material/ListAlt'; // Icon for IOM Templates
+import ArticleIcon from '@mui/icons-material/Article'; // Icon for Generic IOMs
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import DashboardIcon from '@mui/icons-material/Dashboard';
@@ -205,6 +206,7 @@ function HomePage() {
       path: '/security-access',
     },
     { text: 'Reports & Analytics', icon: <AssessmentIcon />, path: '/reports' },
+    { text: 'Internal Memos', icon: <ArticleIcon />, path: '/ioms'}, // Link for Generic IOMs
     // Add new admin/settings link here
     { text: 'IOM Templates', icon: <ListAltIcon />, path: '/admin/iom-templates' },
   ];


### PR DESCRIPTION
- Established frontend module structure (`genericIom`) with pages, components, and types.
- Added routes for listing, selecting templates, creating, viewing, and editing Generic IOMs.
- Added navigation link for 'Internal Memos'.
- Extended `genericIomApi.ts` with functions for GenericIOM CRUD and custom actions (simple approval, publish).
- Defined TypeScript types for GenericIOM data structures in `genericIomTypes.ts`.
- Implemented `SelectIomTemplatePage` for users to choose an IOM template.
- Implemented `DynamicIomFormFieldRenderer` to dynamically render form fields based on template definitions.
- Implemented `GenericIomFormPage` and `GenericIomFormComponent` for creating and editing IOMs using dynamic forms.
- Implemented `GenericIomListPage` and `GenericIomListComponent` to list, filter, sort, and paginate IOMs.
- Implemented `GenericIomDetailPage` and `GenericIomDetailComponent` to display IOM details and provide workflow action buttons.
- Outlined manual test cases for the new functionality.