### PR TITLE
Integrate PurchaseRequestMemo into Generic IOM selection flow.

### DIFF
--- a/itsm_frontend/src/modules/genericIom/components/SelectIomTemplateComponent.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/SelectIomTemplateComponent.tsx
@@ -79,8 +79,15 @@ const SelectIomTemplateComponent: React.FC = () => {
     fetchAndGroupTemplates();
   }, [fetchAndGroupTemplates]);
 
-  const handleTemplateSelect = (templateId: number) => {
-    navigate(`/ioms/new/${templateId}`);
+  const handleTemplateSelect = (template: IOMTemplate) => {
+    // Standard name for the special Purchase Request Memo template
+    const purchaseRequestMemoTemplateName = "Purchase Request Memo";
+
+    if (template.name === purchaseRequestMemoTemplateName) {
+      navigate('/procurement/iom/new');
+    } else {
+      navigate(`/ioms/new/${template.id}`);
+    }
   };
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -156,7 +163,7 @@ const SelectIomTemplateComponent: React.FC = () => {
                 {filteredGroupedTemplates[categoryName].map((template) => (
                   <ListItemButton
                     key={template.id}
-                    onClick={() => handleTemplateSelect(template.id)}
+                    onClick={() => handleTemplateSelect(template)} // Pass the whole template object
                     sx={{borderBottom: '1px solid #eee', '&:last-child': { borderBottom: 0}}}
                   >
                     <ListItemIcon>


### PR DESCRIPTION
- Modified `SelectIomTemplateComponent.tsx` to redirect to the existing `/procurement/iom/new` form when a template named 'Purchase Request Memo' is selected.
- Other templates navigate to the new generic IOM creation form.
- Defined the JSON structure for the 'Purchase Request Memo' IOMTemplate (to be created by an admin) for display consistency.
- Confirmed existing direct links to the specialized PRM form remain functional.
- Provided internal documentation and user communication notes for this change.