### PR TITLE
Implement email notifications for Generic IOM system.

### DIFF
--- a/generic_iom/apps.py
+++ b/generic_iom/apps.py
@@ -1,6 +1,27 @@
 from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
 
 
 class GenericIomConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "generic_iom"
+    verbose_name = _("Generic Internal Office Memos")
+
+    def ready(self):
+        import generic_iom.signals # Import signals to connect them
+
+        # For connecting to ApprovalStep from another app, do it carefully
+        try:
+            from django.db.models.signals import post_save
+            from procurement.models import ApprovalStep
+            from .signals import handle_approval_step_created_for_generic_iom_actual
+            # Rename the actual handler to avoid conflict if signals.py is re-imported by Django multiple times
+
+            post_save.connect(handle_approval_step_created_for_generic_iom_actual, sender=ApprovalStep)
+        except ImportError:
+            # This might happen if procurement app is not installed or during certain management commands
+            # where apps are not fully loaded.
+            pass
+        except Exception as e:
+            # Catch any other exception during connection to prevent app startup failure
+            print(f"Warning: Could not connect signal for ApprovalStep notifications in generic_iom: {e}")

--- a/generic_iom/signals.py
+++ b/generic_iom/signals.py
@@ -1,0 +1,200 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.contrib.auth.models import User, Group # Assuming User is from auth.User
+from django.urls import reverse # For generating URLs to IOMs
+from django.conf import settings # To get site domain for full URLs
+
+from .models import GenericIOM
+# Need to import ApprovalStep carefully due to potential circularity or app loading order
+# from procurement.models import ApprovalStep # This might be problematic if procurement depends on generic_iom
+# Instead, we can use sender=ApprovalStep in the receiver decorator if apps are loaded correctly.
+
+# Assuming email utility exists
+try:
+    from core_api.email_utils import send_notification_email # Corrected function name
+except ImportError:
+    send_notification_email = None # Corrected variable name
+    print("WARNING: core_api.email_utils.send_notification_email not found. Email notifications will be disabled.")
+
+def get_user_emails(users_queryset):
+    """Helper to get emails from a queryset of users, filtering out users without emails."""
+    return list(users_queryset.filter(email__isnull=False, email__exact='').exclude(email='').values_list('email', flat=True))
+
+def get_group_member_emails(group_instance):
+    """Helper to get emails of all members in a group."""
+    if group_instance:
+        return get_user_emails(group_instance.user_set.all())
+    return []
+
+def get_absolute_url(path):
+    # Use settings.SITE_URL or build it. For now, relative path.
+    # This needs to be configured properly for emails to have clickable links.
+    # Example: return f"{settings.SITE_DOMAIN}{path}"
+    # For now, let's just return the path. Frontend will handle full URL.
+    return path
+
+
+@receiver(post_save, sender=GenericIOM)
+def handle_generic_iom_saved(sender, instance: GenericIOM, created, **kwargs):
+    if not send_notification_email: # Corrected check
+        return # Email utility not available
+
+    # Determine previous status if it's an update
+    previous_status = None
+    if not created and hasattr(instance, '_previous_status'): # Check if we attached it before saving
+        previous_status = instance._previous_status
+
+    # Notification 1: Submitted for Simple Approval
+    if instance.status == 'pending_approval' and \
+       (created or (previous_status and previous_status == 'draft')) and \
+       instance.iom_template.approval_type == 'simple':
+
+        recipients = []
+        if instance.iom_template.simple_approval_user:
+            if instance.iom_template.simple_approval_user.email:
+                recipients.append(instance.iom_template.simple_approval_user.email)
+
+        recipients.extend(get_group_member_emails(instance.iom_template.simple_approval_group))
+        recipients = list(set(recipients)) # Unique emails
+
+        if recipients:
+            subject = f"IOM Submitted for Your Approval: {instance.subject} (ID: {instance.gim_id})"
+            # TODO: Construct a proper URL to the IOM detail/approval page on the frontend
+            iom_url = get_absolute_url(f"/ioms/view/{instance.id}") # Placeholder
+            message = (
+                f"Dear Approver,\n\n"
+                f"The Internal Office Memo '{instance.subject}' (ID: {instance.gim_id}) created by {instance.created_by.username if instance.created_by else 'System'} "
+                f"has been submitted for your approval.\n\n"
+                f"Template: {instance.iom_template.name}\n"
+                f"Please review and take action here: {iom_url}\n\n"
+                f"Thank you."
+            )
+            send_notification_email(subject, message, settings.DEFAULT_FROM_EMAIL, recipients) # Corrected call
+
+    # Notification 2: Simple Workflow Outcome (Approved/Rejected)
+    if previous_status == 'pending_approval' and \
+       instance.status in ['approved', 'rejected'] and \
+       instance.iom_template.approval_type == 'simple' and \
+       instance.created_by and instance.created_by.email:
+
+        action_by_username = instance.simple_approver_action_by.username if instance.simple_approver_action_by else "System"
+        outcome = instance.status.capitalize()
+        subject = f"IOM '{instance.subject}' (ID: {instance.gim_id}) has been {outcome}"
+        iom_url = get_absolute_url(f"/ioms/view/{instance.id}")
+        message = (
+            f"Dear {instance.created_by.username},\n\n"
+            f"The IOM '{instance.subject}' (ID: {instance.gim_id}) has been {outcome} by {action_by_username}.\n"
+        )
+        if instance.simple_approval_comments:
+            message += f"\nApprover Comments:\n{instance.simple_approval_comments}\n"
+        message += f"\nYou can view the IOM here: {iom_url}\n\nThank you."
+        send_notification_email(subject, message, settings.DEFAULT_FROM_EMAIL, [instance.created_by.email]) # Corrected call
+
+    # Notification 4: Advanced Workflow Final Outcome (Approved/Rejected)
+    # This is also handled here, assuming the status change to 'approved'/'rejected'
+    # for an 'advanced' template means the workflow is complete.
+    if previous_status == 'pending_approval' and \
+       instance.status in ['approved', 'rejected'] and \
+       instance.iom_template.approval_type == 'advanced' and \
+       instance.created_by and instance.created_by.email:
+
+        # For advanced, the 'approver' field on GenericIOM might not be set for the final step actioner.
+        # We might need to get the last actioner from ApprovalSteps if that detail is needed.
+        # For now, just general notification.
+        outcome = instance.status.capitalize()
+        subject = f"IOM '{instance.subject}' (ID: {instance.gim_id}) - Advanced Workflow {outcome}"
+        iom_url = get_absolute_url(f"/ioms/view/{instance.id}")
+        message = (
+            f"Dear {instance.created_by.username},\n\n"
+            f"The IOM '{instance.subject}' (ID: {instance.gim_id}) submitted through the advanced workflow "
+            f"has been finally {outcome}.\n"
+            f"You can view the IOM here: {iom_url}\n\nThank you."
+        )
+        send_notification_email(subject, message, settings.DEFAULT_FROM_EMAIL, [instance.created_by.email]) # Corrected call
+
+
+    # Notification 5: IOM Published
+    if instance.status == 'published' and (created or (previous_status and previous_status != 'published')):
+        recipients = []
+        recipients.extend(get_user_emails(instance.to_users.all()))
+        for group in instance.to_groups.all():
+            recipients.extend(get_group_member_emails(group))
+        recipients = list(set(recipients)) # Unique emails
+
+        if recipients:
+            subject = f"New IOM Published: {instance.subject} (ID: {instance.gim_id})"
+            iom_url = get_absolute_url(f"/ioms/view/{instance.id}")
+            # Consider adding a snippet of data_payload if safe and meaningful
+            message = (
+                f"Dear Colleagues,\n\n"
+                f"A new Internal Office Memo has been published:\n"
+                f"Title: {instance.subject}\n"
+                f"ID: {instance.gim_id}\n"
+                f"Template: {instance.iom_template.name}\n"
+                f"Published by: {instance.created_by.username if instance.created_by else 'System'}\n\n"
+                f"You can view the IOM here: {iom_url}\n\n"
+                f"Thank you."
+            )
+            send_notification_email(subject, message, settings.DEFAULT_FROM_EMAIL, recipients) # Corrected call
+
+# To get previous status for GenericIOM
+@receiver(models.signals.pre_save, sender=GenericIOM)
+def store_previous_generic_iom_status(sender, instance, **kwargs):
+    if instance.pk:
+        try:
+            instance._previous_status = GenericIOM.objects.get(pk=instance.pk).status
+        except GenericIOM.DoesNotExist:
+            instance._previous_status = None
+
+
+# Receiver for ApprovalStep creation (Notification 3)
+# This needs to be dynamically connected if ApprovalStep is in another app to avoid AppRegistryNotReady
+# or ensure generic_iom app is loaded after procurement.
+# For now, we'll try a direct connection. If it fails at startup, will move to apps.py.
+
+# Deferring direct import of ApprovalStep to function scope or apps.py to handle potential AppNotReady issues.
+# Renamed to _actual as it's connected in apps.py
+def handle_approval_step_created_for_generic_iom_actual(sender, instance, created, **kwargs):
+    if not send_notification_email: # Corrected check
+        return
+
+    # Check if this ApprovalStep is for a GenericIOM and if it's newly created and pending
+    if created and instance.status == 'pending':
+        # Need to get ContentType for GenericIOM to check instance.content_type
+        # This import should be safe within the function if apps are loaded.
+        from django.contrib.contenttypes.models import ContentType
+        from .models import GenericIOM as GenericIOMModel # Use an alias to avoid confusion
+
+        generic_iom_content_type = ContentType.objects.get_for_model(GenericIOMModel)
+
+        if instance.content_type == generic_iom_content_type:
+            # The instance.content_object should be a GenericIOM instance
+            g_iom = instance.content_object
+            if not isinstance(g_iom, GenericIOMModel):
+                # Should not happen if content_type matches, but good to be safe
+                return
+
+            recipients = []
+            if instance.assigned_approver_user and instance.assigned_approver_user.email:
+                recipients.append(instance.assigned_approver_user.email)
+
+            recipients.extend(get_group_member_emails(instance.assigned_approver_group))
+            recipients = list(set(recipients))
+
+            if recipients:
+                subject = f"Action Required: Approval Step for IOM '{g_iom.subject}' (ID: {g_iom.gim_id})"
+                # TODO: Construct a proper URL to the approval task/IOM detail page on the frontend
+                iom_url = get_absolute_url(f"/ioms/view/{g_iom.id}") # Placeholder
+                # Could also link to a specific "my approvals" page: get_absolute_url("/my-approvals")
+
+                message = (
+                    f"Dear Approver,\n\n"
+                    f"A new approval step has been assigned to you (or your group) for the Internal Office Memo:\n"
+                    f"Title: {g_iom.subject}\n"
+                    f"ID: {g_iom.gim_id}\n"
+                    f"Template: {g_iom.iom_template.name}\n"
+                    f"Step Details: {instance.rule_name_snapshot or f'Step Order {instance.step_order}'}\n\n"
+                    f"Please review and take action here: {iom_url}\n\n"
+                    f"Thank you."
+                )
+                send_notification_email(subject, message, settings.DEFAULT_FROM_EMAIL, recipients) # Corrected call

--- a/generic_iom/tests/test_signals.py
+++ b/generic_iom/tests/test_signals.py
@@ -1,0 +1,239 @@
+from django.test import TestCase, override_settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
+from unittest.mock import patch, MagicMock
+
+from generic_iom.models import IOMCategory, IOMTemplate, GenericIOM
+# Import ApprovalStep if we are testing signals related to it.
+# For these tests, we will focus on GenericIOM signals first.
+# We might need to create ApprovalStep instances if testing the handle_approval_step_created signal.
+try:
+    from procurement.models import ApprovalStep, ApprovalRule
+    PROCUREMENT_MODELS_AVAILABLE = True
+except ImportError:
+    PROCUREMENT_MODELS_AVAILABLE = False
+    ApprovalStep = None
+    ApprovalRule = None
+
+
+User = get_user_model()
+
+# This path needs to match where send_notification_email is actually located and imported in signals.py
+# If signals.py imports it as `from core_api.email_utils import send_notification_email`
+# then the path to mock is 'generic_iom.signals.send_notification_email'
+EMAIL_UTIL_PATH = 'generic_iom.signals.send_notification_email'
+
+@override_settings(FRONTEND_BASE_URL="http://localhost:3000") # For get_absolute_url if it uses settings
+class GenericIOMSignalTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.creator = User.objects.create_user(username='creator', email='creator@example.com', password='password')
+        cls.approver_user = User.objects.create_user(username='approver', email='approver@example.com', password='password')
+        cls.recipient_user1 = User.objects.create_user(username='recipient1', email='recipient1@example.com', password='password')
+        cls.recipient_user2 = User.objects.create_user(username='recipient2', email='recipient2@example.com', password='password')
+
+        cls.approver_group = Group.objects.create(name='Simple Approvers')
+        cls.approver_user.groups.add(cls.approver_group) # Add approver_user to the group as well for testing group + individual
+
+        cls.recipient_group = Group.objects.create(name='IOM Recipients Group')
+        cls.recipient_user2.groups.add(cls.recipient_group) # recipient_user2 is also in this group
+
+        cls.category = IOMCategory.objects.create(name="Notification Test Category")
+
+        cls.template_simple = IOMTemplate.objects.create(
+            name="Simple Approval Notify Template",
+            created_by=cls.creator,
+            category=cls.category,
+            approval_type='simple',
+            simple_approval_user=cls.approver_user,
+            # simple_approval_group=cls.approver_group # Test with user first, then group
+        )
+        cls.template_simple_group_approver = IOMTemplate.objects.create(
+            name="Simple Group Approval Notify Template",
+            created_by=cls.creator,
+            category=cls.category,
+            approval_type='simple',
+            simple_approval_group=cls.approver_group
+        )
+        cls.template_advanced = IOMTemplate.objects.create(
+            name="Advanced Approval Notify Template",
+            created_by=cls.creator,
+            category=cls.category,
+            approval_type='advanced'
+        )
+        cls.template_no_approval = IOMTemplate.objects.create(
+            name="No Approval Notify Template",
+            created_by=cls.creator,
+            category=cls.category,
+            approval_type='none'
+        )
+        if PROCUREMENT_MODELS_AVAILABLE:
+             cls.adv_approval_rule = ApprovalRule.objects.create(
+                name="Generic Advanced Rule",
+                rule_type='generic_iom',
+                order=1,
+                approver_user=cls.approver_user
+            )
+             cls.adv_approval_rule.applicable_iom_templates.add(cls.template_advanced)
+
+
+    @patch(EMAIL_UTIL_PATH)
+    def test_signal_iom_submitted_for_simple_approval_user(self, mock_send_email):
+        iom = GenericIOM(
+            iom_template=self.template_simple,
+            subject="Test Simple Submit User",
+            created_by=self.creator,
+            status='draft' # Start as draft
+        )
+        iom.save() # This should set GIM_ID
+
+        # Now change status to trigger notification
+        iom.status = 'pending_approval'
+        iom.save() # This save should trigger the notification
+
+        mock_send_email.assert_called_once()
+        args, kwargs = mock_send_email.call_args
+        self.assertIn("Submitted for Your Approval", args[0]) # Subject
+        self.assertIn(self.approver_user.email, args[2]) # Recipient list
+
+    @patch(EMAIL_UTIL_PATH)
+    def test_signal_iom_submitted_for_simple_approval_group(self, mock_send_email):
+        iom = GenericIOM(
+            iom_template=self.template_simple_group_approver,
+            subject="Test Simple Submit Group",
+            created_by=self.creator,
+            status='draft'
+        )
+        iom.save()
+        iom.status = 'pending_approval'
+        iom.save()
+
+        mock_send_email.assert_called_once()
+        args, kwargs = mock_send_email.call_args
+        self.assertIn("Submitted for Your Approval", args[0])
+        self.assertIn(self.approver_user.email, args[2]) # User is in approver_group
+
+    @patch(EMAIL_UTIL_PATH)
+    def test_signal_iom_simple_workflow_outcome_approved(self, mock_send_email):
+        iom = GenericIOM.objects.create(
+            iom_template=self.template_simple,
+            subject="Test Simple Outcome Approved",
+            created_by=self.creator,
+            status='pending_approval', # Start as pending
+            simple_approver_action_by=self.approver_user
+        )
+        iom.status = 'approved'
+        iom.save() # Trigger notification
+
+        mock_send_email.assert_called_once()
+        args, kwargs = mock_send_email.call_args
+        self.assertIn("has been Approved", args[0]) # Subject
+        self.assertEqual(args[2], [self.creator.email]) # Recipient is creator
+
+    @patch(EMAIL_UTIL_PATH)
+    def test_signal_iom_simple_workflow_outcome_rejected(self, mock_send_email):
+        iom = GenericIOM.objects.create(
+            iom_template=self.template_simple,
+            subject="Test Simple Outcome Rejected",
+            created_by=self.creator,
+            status='pending_approval',
+            simple_approver_action_by=self.approver_user,
+            simple_approval_comments="Not good enough"
+        )
+        iom.status = 'rejected'
+        iom.save()
+
+        mock_send_email.assert_called_once()
+        args, kwargs = mock_send_email.call_args
+        self.assertIn("has been Rejected", args[0])
+        self.assertIn("Not good enough", args[1]) # Check for comments in message
+        self.assertEqual(args[2], [self.creator.email])
+
+    @patch(EMAIL_UTIL_PATH)
+    @unittest.skipIf(not PROCUREMENT_MODELS_AVAILABLE, "Procurement models (ApprovalStep) not available for this test")
+    def test_signal_advanced_approval_step_assigned(self, mock_send_email):
+        # This test relies on GenericIOM.trigger_advanced_approval_workflow creating an ApprovalStep
+        # which then triggers its own post_save signal handled by handle_approval_step_created_for_generic_iom_actual
+
+        # Create the IOM, its save() will trigger workflow and create steps
+        iom = GenericIOM.objects.create(
+            iom_template=self.template_advanced,
+            subject="Test Adv Step Assigned",
+            created_by=self.creator,
+            status='draft' # This will transition to pending_approval and create steps
+        )
+        # The signal for ApprovalStep creation should have fired.
+        # Note: The mock is on generic_iom.signals.send_notification_email.
+        # The handle_approval_step_created_for_generic_iom_actual calls this.
+
+        self.assertTrue(mock_send_email.called)
+        # We might have multiple calls if other signals fired too. Let's check the last relevant one.
+        # Or check call_args_list
+        found_adv_step_email = False
+        for call_args_item in mock_send_email.call_args_list:
+            args, kwargs = call_args_item
+            if "Action Required: Approval Step" in args[0]:
+                self.assertIn(self.approver_user.email, args[2])
+                self.assertIn(iom.subject, args[1])
+                found_adv_step_email = True
+                break
+        self.assertTrue(found_adv_step_email, "Advanced approval step assignment email not sent.")
+
+
+    @patch(EMAIL_UTIL_PATH)
+    @unittest.skipIf(not PROCUREMENT_MODELS_AVAILABLE, "Procurement models not available for this test")
+    def test_signal_iom_advanced_workflow_outcome(self, mock_send_email):
+        # Setup: Create IOM, it goes to pending_approval with steps
+        iom = GenericIOM.objects.create(
+            iom_template=self.template_advanced,
+            subject="Test Adv Outcome",
+            created_by=self.creator,
+            status='draft'
+        )
+        self.assertEqual(iom.status, 'pending_approval') # From trigger_advanced_approval_workflow
+        mock_send_email.reset_mock() # Reset from step assignment email
+
+        # Simulate the IOM being approved via advanced workflow
+        # This normally happens when all its ApprovalSteps are completed and a final signal/logic updates GenericIOM.
+        # For this test, we manually change the GenericIOM status as if that happened.
+        iom.status = 'approved'
+        iom.save()
+
+        # We expect one call for the "Advanced Workflow Approved" to creator
+        # mock_send_email.assert_called_once() # This might fail if other signals are also triggered by save
+        self.assertTrue(mock_send_email.called)
+        args, kwargs = mock_send_email.call_args # Check the last call
+        self.assertIn("Advanced Workflow Approved", args[0])
+        self.assertEqual(args[2], [self.creator.email])
+
+
+    @patch(EMAIL_UTIL_PATH)
+    def test_signal_iom_published(self, mock_send_email):
+        iom = GenericIOM.objects.create(
+            iom_template=self.template_no_approval,
+            subject="Test Published IOM",
+            created_by=self.creator,
+            status='approved' # Or 'draft' if no approval template
+        )
+        iom.to_users.add(self.recipient_user1)
+        iom.to_groups.add(self.recipient_group) # recipient_user2 is in this group
+
+        iom.status = 'published'
+        iom.save()
+
+        mock_send_email.assert_called_once()
+        args, kwargs = mock_send_email.call_args
+        self.assertIn("New IOM Published", args[0])
+        # Expected recipients: recipient_user1, and recipient_user2 (from group)
+        # Note: approver_user (self.approver_user) is also in self.recipient_group via setup.
+        # So, if self.approver_user has an email, it should be in the list.
+        expected_emails = {self.recipient_user1.email, self.recipient_user2.email}
+        if self.approver_user.email: # If approver_user (who is in recipient_group) has an email
+            expected_emails.add(self.approver_user.email)
+
+        self.assertEqual(set(args[2]), expected_emails)
+
+# Need to import unittest for skipIf
+import unittest


### PR DESCRIPTION
- Created `generic_iom/signals.py` with signal handlers for `GenericIOM` post_save and `procurement.ApprovalStep` post_save (for GenericIOM content_object).
- Notifications implemented for:
  - IOM submitted for simple approval.
  - Simple workflow outcome (approved/rejected) to creator.
  - Advanced approval step assignment.
  - Advanced workflow final outcome to creator.
  - IOM publication to recipients.
- Connected signals in `generic_iom/apps.py`.
- Updated `generic_iom/signals.py` to use correct `send_notification_email` from `core_api.email_utils`.
- Added unit tests for signal handlers in `generic_iom/tests/test_signals.py`, mocking email sending.
- Provided internal documentation for the notification system.