### PR TITLE
Fix: Resolve NameError for 'models' in generic_iom/signals.py

### DIFF
--- a/generic_iom/signals.py
+++ b/generic_iom/signals.py
@@ -1,4 +1,4 @@
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, pre_save # Import pre_save
 from django.dispatch import receiver
 from django.contrib.auth.models import User, Group # Assuming User is from auth.User
 from django.urls import reverse # For generating URLs to IOMs
@@ -138,7 +138,7 @@ def handle_generic_iom_saved(sender, instance: GenericIOM, created, **kwargs):
             send_notification_email(subject, message, settings.DEFAULT_FROM_EMAIL, recipients) # Corrected call
 
 # To get previous status for GenericIOM
-@receiver(models.signals.pre_save, sender=GenericIOM)
+@receiver(pre_save, sender=GenericIOM) # Use imported pre_save
 def store_previous_generic_iom_status(sender, instance, **kwargs):
     if instance.pk:
         try:


### PR DESCRIPTION
Corrected the usage of the `pre_save` signal in the `@receiver` decorator by importing `pre_save` directly from `django.db.models.signals`. This resolves the `NameError: name 'models' is not defined` that occurred during server startup when loading the generic_iom app's signals.