### PR TITLE
Feat: Implement review & approval UI for Generic IOM advanced workflows.

### DIFF
--- a/itsm_frontend/src/api/procurementApi.ts
+++ b/itsm_frontend/src/api/procurementApi.ts
@@ -375,6 +375,57 @@ export const cancelCheckRequest = async (
 
 // --- (Optional) OrderItem Functions ---
 // ... (existing commented out OrderItem functions remain unchanged) ...
+
+// --- Approval Step API Functions ---
+
+export const getApprovalSteps = async (
+  authenticatedFetch: AuthenticatedFetch,
+  params?: GetApprovalStepsParams
+): Promise<PaginatedResponse<ApprovalStep>> => {
+  const queryParams = new URLSearchParams();
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        // Map frontend param names to backend if they differ, e.g. content_type_app_label to content_type__app_label
+        if (key === 'pageSize') queryParams.append('page_size', String(value));
+        else if (key === 'content_type_app_label') queryParams.append('content_type__app_label', String(value));
+        else if (key === 'content_type_model') queryParams.append('content_type__model', String(value));
+        else queryParams.append(key, String(value));
+      }
+    });
+  }
+  // Assuming approval steps are under procurement API path
+  const endpoint = `${API_PROCUREMENT_PATH}/approval-steps/${queryParams.toString() ? '?' : ''}${queryParams.toString()}`;
+  return (await authenticatedFetch(endpoint, { method: 'GET' })) as PaginatedResponse<ApprovalStep>;
+};
+
+export const approveApprovalStep = async (
+  authenticatedFetch: AuthenticatedFetch,
+  stepId: number,
+  payload: ApprovalActionPayload
+): Promise<ApprovalStep> => {
+  const endpoint = `${API_PROCUREMENT_PATH}/approval-steps/${stepId}/approve/`;
+  return (await authenticatedFetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })) as ApprovalStep;
+};
+
+export const rejectApprovalStep = async (
+  authenticatedFetch: AuthenticatedFetch,
+  stepId: number,
+  payload: ApprovalActionPayload // Comments are mandatory for rejection via backend logic
+): Promise<ApprovalStep> => {
+  const endpoint = `${API_PROCUREMENT_PATH}/approval-steps/${stepId}/reject/`;
+  return (await authenticatedFetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })) as ApprovalStep;
+};
+
+
 /*
 export const getOrderItems = async (
   authenticatedFetch: AuthenticatedFetch,

--- a/itsm_frontend/src/modules/procurement/types/procurementTypes.ts
+++ b/itsm_frontend/src/modules/procurement/types/procurementTypes.ts
@@ -434,3 +434,50 @@ export interface RecurringPaymentForDropdown {
 // If procurementApi.ts specifically needs a Vendor type from *this* file for some reason (e.g. a simplified version for a dropdown),
 // it would be defined here. However, PurchaseRequestMemoForm.tsx correctly imports Vendor from assetApi.ts.
 // The errors listed for procurementApi.ts suggest it *expects* these common types (Department, Project etc.) from this file.
+
+
+// --- Approval Step Types ---
+export interface ApprovalStep {
+  id: number;
+  // GFK fields like content_type (ID), object_id are usually not directly exposed or used by frontend.
+  // Instead, custom fields from serializer provide context.
+  content_object_display: string | null; // User-friendly display of the item being approved (e.g., "PRM: IOM-001 - Laptop" or "GIM: GIM-002 - Policy Update")
+  content_object_url: string | null;     // Frontend URL path to view the item being approved
+
+  approval_rule?: number | null;          // ID of the ApprovalRule
+  approval_rule_name?: string | null;
+  rule_name_snapshot?: string | null;
+  step_order: number;
+
+  assigned_approver_user?: number | null; // User ID
+  assigned_approver_user_name?: string | null;
+  assigned_approver_group?: number | null; // Group ID
+  assigned_approver_group_name?: string | null;
+
+  status: 'pending' | 'approved' | 'rejected' | 'skipped' | 'delegated';
+  status_display: string;
+
+  approved_by?: number | null; // User ID of the user who actioned this step
+  actioned_by_user_name?: string | null;
+  decision_date?: string | null; // ISO datetime string
+  comments?: string | null;
+
+  created_at: string; // ISO datetime string
+  updated_at: string; // ISO datetime string
+}
+
+export interface GetApprovalStepsParams {
+  page?: number;
+  pageSize?: number;
+  ordering?: string;
+  status?: 'pending' | 'approved' | 'rejected' | 'skipped' | 'delegated';
+  // To filter by related object (e.g., all steps for a specific GenericIOM or PurchaseRequestMemo)
+  content_type_app_label?: string; // e.g., 'generic_iom' or 'procurement'
+  content_type_model?: string;     // e.g., 'genericiom' or 'purchaserequestmemo'
+  object_id?: number;
+  // Could add a param like assigned_to_me=true for the backend to resolve current user's steps
+}
+
+export interface ApprovalActionPayload {
+  comments: string; // Comments are typically required for rejection, optional for approval
+}

--- a/itsm_frontend/src/modules/workflows/pages/MyApprovalsPage.tsx
+++ b/itsm_frontend/src/modules/workflows/pages/MyApprovalsPage.tsx
@@ -1,19 +1,29 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import {
-  Box, Typography, Button, CircularProgress, Alert, Dialog, DialogTitle, DialogContent, TextField, DialogActions, Chip
+  Box, Typography, Button, CircularProgress, Alert, Dialog, DialogTitle, DialogContent, TextField, DialogActions, Chip, Tooltip
 } from '@mui/material';
 import { DataGrid, type GridColDef, GridActionsCellItem } from '@mui/x-data-grid';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
-import { type ApprovalStep, type ApprovalActionPayload } from '../types'; // Added ApprovalRequest
-import { getMyApprovalSteps, approveStep, rejectStep, getApprovalRequestById } from '../api';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { Link as RouterLink } from 'react-router-dom';
+
+import {
+  type ApprovalStep,
+  type ApprovalActionPayload,
+  type GetApprovalStepsParams
+} from '../../procurement/types/procurementTypes'; // Use types from procurement
+import {
+  getApprovalSteps,
+  approveApprovalStep,
+  rejectApprovalStep
+} from '../../../api/procurementApi'; // Use API functions from procurement
 import { useUI } from '../../../context/UIContext/useUI';
-import { useAuth } from '../../../context/auth/useAuth'; // Import useAuth
-// import type { AuthenticatedFetch } from '../../../context/auth/AuthContextDefinition'; // Removed as it's unused for explicit type annotation
+import { useAuth } from '../../../context/auth/useAuth';
 
 const MyApprovalsPage: React.FC = () => {
   const { showSnackbar } = useUI();
-  const { authenticatedFetch, isAuthenticated, loading: authLoading } = useAuth(); // Destructure from useAuth
+  const { authenticatedFetch, isAuthenticated, loading: authLoading } = useAuth();
   const [myPendingSteps, setMyPendingSteps] = useState<ApprovalStep[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -24,15 +34,11 @@ const MyApprovalsPage: React.FC = () => {
   const [comments, setComments] = useState('');
   const [isSubmittingAction, setIsSubmittingAction] = useState(false);
 
-  const [requestDetails, setRequestDetails] = useState<Record<number, { title: string, contentDisplay?: string, created_at?: string }>>({});
-
-  // FIX: Add dependency array to useCallback
   const fetchMyPendingSteps = useCallback(async () => {
     if (!isAuthenticated && !authLoading) {
       setError("User is not authenticated. Cannot load approvals.");
       setLoading(false);
       setMyPendingSteps([]);
-      setRequestDetails({});
       return;
     }
     if (authLoading) {
@@ -42,51 +48,37 @@ const MyApprovalsPage: React.FC = () => {
     if (!authenticatedFetch) return;
 
     setLoading(true);
+    const params: GetApprovalStepsParams = { status: 'pending', pageSize: 100 };
     try {
-      const steps = await getMyApprovalSteps(authenticatedFetch, 'pending');
-      setMyPendingSteps(steps);
+      const response = await getApprovalSteps(authenticatedFetch, params);
+      setMyPendingSteps(response.results);
       setError(null);
-
-      if (steps.length > 0) {
-        const uniqueRequestIds = Array.from(new Set(steps.map(step => step.approval_request)));
-        const detailsPromises = uniqueRequestIds.map(id => getApprovalRequestById(authenticatedFetch, id));
-        const fetchedRequests = await Promise.all(detailsPromises);
-
-        const detailsMap: Record<number, { title: string, contentDisplay?: string, created_at?: string }> = {};
-        fetchedRequests.forEach(req => {
-          detailsMap[req.id] = {
-            title: req.title,
-            contentDisplay: req.content_object_display?.display || req.content_object_display?.title || `Item ID: ${req.object_id} (Type: ${req.content_object_display?.type})`,
-            created_at: req.created_at, // Store created_at from the request
-          };
-        });
-        setRequestDetails(detailsMap);
-      } else {
-        setRequestDetails({});
-      }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : 'Failed to fetch pending approvals.';
       setError(errorMsg);
       showSnackbar(errorMsg, 'error');
       setMyPendingSteps([]);
-      setRequestDetails({});
     } finally {
       setLoading(false);
     }
   }, [showSnackbar, authenticatedFetch, isAuthenticated, authLoading]);
 
   useEffect(() => {
-    if (!authLoading) {
+    if (!authLoading && isAuthenticated) { // Only fetch if authenticated
       fetchMyPendingSteps();
+    } else if (!authLoading && !isAuthenticated) {
+      setLoading(false); // Stop loading if not authenticated
+      setMyPendingSteps([]); // Clear any existing steps
+      setError("Please log in to view your approvals."); // Set an informative error
     } else {
-      setLoading(true);
+      setLoading(true); // Still loading auth status
     }
-  }, [fetchMyPendingSteps, authLoading]);
+  }, [fetchMyPendingSteps, authLoading, isAuthenticated]);
 
   const handleOpenActionDialog = (step: ApprovalStep, type: 'approve' | 'reject') => {
     setCurrentStep(step);
     setActionType(type);
-    setComments('');
+    setComments(step.comments || ''); // Pre-fill comments if any exist (e.g. from previous rejection)
     setActionDialogOpen(true);
   };
 
@@ -94,6 +86,7 @@ const MyApprovalsPage: React.FC = () => {
     setActionDialogOpen(false);
     setCurrentStep(null);
     setActionType(null);
+    setComments(''); // Clear comments on close
   };
 
   const handleSubmitAction = async () => {
@@ -102,19 +95,22 @@ const MyApprovalsPage: React.FC = () => {
       showSnackbar('User not authenticated. Cannot perform action.', 'error');
       return;
     }
+
+    if (actionType === 'reject' && !comments.trim()) {
+        showSnackbar('Comments are required for rejection.', 'warning');
+        // setError('Comments are required for rejection.'); // Not setting global error for this
+        return;
+    }
+
     setIsSubmittingAction(true);
     const payload: ApprovalActionPayload = { comments };
     try {
       if (actionType === 'approve') {
-        await approveStep(authenticatedFetch, currentStep.id, payload);
+        await approveApprovalStep(authenticatedFetch, currentStep.id, payload);
         showSnackbar('Step approved successfully!', 'success');
       } else if (actionType === 'reject') {
-        await rejectStep(authenticatedFetch, currentStep.id, payload);
+        await rejectApprovalStep(authenticatedFetch, currentStep.id, payload);
         showSnackbar('Step rejected successfully!', 'success');
-      } else {
-        showSnackbar(`Invalid action: ${actionType}`, 'error');
-        setIsSubmittingAction(false);
-        return;
       }
       await fetchMyPendingSteps();
       handleCloseActionDialog();
@@ -133,34 +129,35 @@ const MyApprovalsPage: React.FC = () => {
 
   const columns: GridColDef<ApprovalStep>[] = [
     {
-      field: 'approval_request_title',
-      headerName: 'Approval For',
-      width: 300,
-      valueGetter: (_value, row) => requestDetails[row.approval_request]?.title || `Request ID: ${row.approval_request}`,
+      field: 'content_object_display',
+      headerName: 'Item for Approval',
+      width: 350,
+      renderCell: (params) => (
+        <Tooltip title={params.value || ''}>
+            <Typography variant="body2" noWrap>
+            {params.value || 'N/A'}
+            </Typography>
+        </Tooltip>
+      )
     },
     {
-      field: 'content_object',
-      headerName: 'Related Item',
-      width: 300,
-      renderCell: (params) => {
-        const detail = requestDetails[params.row.approval_request];
-        return (
-          <Typography variant="body2">
-            {detail?.contentDisplay || 'N/A'}
-          </Typography>
-        );
-      }
+      field: 'rule_name_snapshot',
+      headerName: 'Approval Rule / Step Name',
+      width: 250,
+      valueGetter: (_value, row) => row.rule_name_snapshot || row.approval_rule_name || `Step ${row.step_order}`
     },
-    { field: 'step_order', headerName: 'Step', width: 80 },
-    { field: 'status', headerName: 'Status', width: 120, renderCell: (params) => <Chip label={params.value} size="small" /> },
+    { field: 'step_order', headerName: 'Order', width: 80, align: 'center' },
     {
-      field: 'approval_request_created_at',
-      headerName: 'Request Created',
+      field: 'status_display',
+      headerName: 'Status',
+      width: 120,
+      renderCell: (params) => <Chip label={params.value || params.row.status} size="small" />
+    },
+    {
+      field: 'created_at',
+      headerName: 'Step Assigned',
       width: 180,
-      valueGetter: (_value, row) => {
-        const req = requestDetails[row.approval_request];
-        return req?.created_at ? formatDate(req.created_at) : 'Loading...';
-      }
+      valueGetter: (_value, row) => formatDate(row.created_at)
     },
     {
       field: 'actions',
@@ -168,6 +165,16 @@ const MyApprovalsPage: React.FC = () => {
       headerName: 'Actions',
       width: 150,
       getActions: ({ row }) => [
+        <GridActionsCellItem
+          icon={<OpenInNewIcon color="info" />}
+          label="View Item"
+          component={RouterLink}
+          to={row.content_object_url || '#'}
+          target="_blank"
+          disabled={!row.content_object_url}
+          key={`view-${row.id}`}
+          sx={!row.content_object_url ? { display: 'none' } : {}}
+        />,
         <GridActionsCellItem
           icon={<CheckCircleOutlineIcon color="success" />}
           label="Approve"
@@ -184,29 +191,16 @@ const MyApprovalsPage: React.FC = () => {
     },
   ];
 
-  if (authLoading && myPendingSteps.length === 0) {
+  if (authLoading || (loading && myPendingSteps.length === 0 && isAuthenticated)) {
     return <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}><CircularProgress /></Box>;
   }
-  if (loading && myPendingSteps.length === 0 && !authLoading && isAuthenticated ) {
-     return <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}><CircularProgress /></Box>;
-  }
-
 
   if (!isAuthenticated && !authLoading) {
     return (
       <Box sx={{ p: 3, width: '100%' }}>
         <Typography variant="h5" component="h1" sx={{ mb: 2 }}>My Pending Approvals</Typography>
-        <Alert severity="info">Please log in to view your pending approvals.</Alert>
+        <Alert severity="info">{error || "Please log in to view your pending approvals."}</Alert>
       </Box>
-    );
-  }
-
-  if (error && myPendingSteps.length === 0 && isAuthenticated && !authLoading) {
-    return (
-        <Box sx={{ p: 3, width: '100%' }}>
-            <Typography variant="h5" component="h1" sx={{ mb: 2 }}>My Pending Approvals</Typography>
-            <Alert severity="error" sx={{ m: 2 }}>{error}</Alert>
-        </Box>
     );
   }
 
@@ -215,46 +209,62 @@ const MyApprovalsPage: React.FC = () => {
       <Typography variant="h5" component="h1" gutterBottom>
         My Pending Approvals
       </Typography>
-      {error && myPendingSteps.length > 0 && <Alert severity="warning" sx={{ mb: 2 }}>{`Error fetching updates: ${error}`}</Alert>}
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
-      {myPendingSteps.length === 0 && !loading && !error && isAuthenticated && !authLoading && (
+      {!loading && !error && myPendingSteps.length === 0 && (
          <Typography sx={{mt: 2}}>You have no pending approvals.</Typography>
       )}
 
-      {(myPendingSteps.length > 0 || loading) && ! (error && myPendingSteps.length === 0) && (
+      {myPendingSteps.length > 0 && !error && (
         <Box sx={{ height: 600, width: '100%', mt: 2 }}>
           <DataGrid
             rows={myPendingSteps}
             columns={columns}
             pageSizeOptions={[10, 25, 50]}
             initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
-            loading={loading && isAuthenticated}
+            loading={loading} // DataGrid's own loading prop
           />
         </Box>
       )}
 
       <Dialog open={actionDialogOpen} onClose={handleCloseActionDialog} maxWidth="sm" fullWidth>
-        <DialogTitle>{actionType === 'approve' ? 'Approve Step' : 'Reject Step'}</DialogTitle>
+        <DialogTitle>{actionType?.replace(/^\w/, c => c.toUpperCase())} Approval Step</DialogTitle>
         <DialogContent>
-          <Typography variant="subtitle1">
-            Item: {currentStep && requestDetails[currentStep.approval_request]?.title}
+          <Typography variant="subtitle1" gutterBottom>
+            Item: {currentStep?.content_object_display || 'N/A'}
           </Typography>
-          <Typography variant="body2" gutterBottom>
-            Details: {currentStep && requestDetails[currentStep.approval_request]?.contentDisplay}
-          </Typography>
+          {currentStep?.content_object_url && (
+            <Button
+                size="small"
+                startIcon={<OpenInNewIcon />}
+                component={RouterLink}
+                to={currentStep.content_object_url}
+                target="_blank"
+                sx={{mb:1}}
+            >
+                View Full Item
+            </Button>
+          )}
           <TextField
-            label="Comments (Optional)"
+            label={`Comments ${actionType === 'reject' ? '(Required)' : '(Optional)'}`}
             value={comments}
             onChange={(e) => setComments(e.target.value)}
             fullWidth
             multiline
             rows={3}
             margin="normal"
+            error={actionType === 'reject' && !comments.trim() && isSubmittingAction} // Show error if reject and no comments during submit attempt
+            helperText={actionType === 'reject' && !comments.trim() && isSubmittingAction ? "Comments are required for rejection." : ""}
           />
         </DialogContent>
         <DialogActions>
           <Button onClick={handleCloseActionDialog} disabled={isSubmittingAction}>Cancel</Button>
-          <Button onClick={handleSubmitAction} variant="contained" color={actionType === 'approve' ? 'success' : 'error'} disabled={isSubmittingAction}>
+          <Button
+            onClick={handleSubmitAction}
+            variant="contained"
+            color={actionType === 'approve' ? 'success' : 'error'}
+            disabled={isSubmittingAction || (actionType === 'reject' && !comments.trim())}
+          >
             {isSubmittingAction ? <CircularProgress size={24} /> : (actionType === 'approve' ? 'Approve' : 'Reject')}
           </Button>
         </DialogActions>


### PR DESCRIPTION
- Enhanced `ApprovalStepSerializer` to provide `content_object_display` and `content_object_url` for GFK-linked items (PurchaseRequestMemo or GenericIOM).
- Updated frontend types for `ApprovalStep` in `procurementTypes.ts`.
- Added/updated API client functions in `procurementApi.ts` for fetching and actioning approval steps (`getApprovalSteps`, `approveApprovalStep`, `rejectApprovalStep`).
- Refactored `MyApprovalsPage.tsx` to:
  - Use the updated API functions and types.
  - Remove secondary data fetching for 'Approval Requests'.
  - Display `content_object_display` and a link via `content_object_url` in the approvals list and action dialog, making it suitable for GenericIOMs.
  - Enforce comments for rejection in the UI.
- Outlined manual test cases for the updated approvals UI.
- Provided internal documentation for these changes.