### PR TITLE
Further fix ESLint, TypeScript errors and update types

### DIFF
--- a/itsm_frontend/src/modules/genericIom/components/GenericIomDetailComponent.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/GenericIomDetailComponent.tsx
@@ -229,8 +229,8 @@ const GenericIomDetailComponent: React.FC<GenericIomDetailComponentProps> = ({ i
 
   const isSimpleApprover = iom.iom_template_details?.approval_type === 'simple' &&
                          (iom.iom_template_details?.simple_approval_user === user?.id ||
-                          ((user as any)?.groups && iom.iom_template_details?.simple_approval_group && // Added 'as any' for groups temporarily
-                           (user as any).groups.some((g: { id: number }) => g.id === iom.iom_template_details?.simple_approval_group)));
+                          (user?.groups && iom.iom_template_details?.simple_approval_group &&
+                           user.groups.some(g => g.id === iom.iom_template_details?.simple_approval_group))); // Removed 'as any' and explicit type for g
 
   const canPerformSimpleApprovalAction = iom.status === 'pending_approval' && isSimpleApprover;
 

--- a/itsm_frontend/src/modules/genericIom/components/GenericIomForm.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/GenericIomForm.tsx
@@ -23,7 +23,7 @@ import { getGenericIomById, createGenericIom, updateGenericIom } from '../../../
 import { getContentTypeId as fetchContentTypeIdFromApi } from '../../../api/coreApi'; // Import the real API call
 import type { IOMTemplate, FieldDefinition } from '../../iomTemplateAdmin/types/iomTemplateAdminTypes'; // FieldDefinition kept as IOMTemplate uses it
 import type { GenericIOMCreateData, GenericIOMUpdateData, IomDataPayload } from '../types/genericIomTypes'; // GenericIOM removed
-import DynamicIomFormFieldRenderer, { FormFieldValue } from './DynamicIomFormFieldRenderer'; // The dynamic renderer, FormFieldValue imported
+import DynamicIomFormFieldRenderer, { type FormFieldValue } from './DynamicIomFormFieldRenderer'; // FormFieldValue to type-only import
 
 // Define the type for assetContext prop
 interface AssetContextType {
@@ -96,7 +96,7 @@ const GenericIomForm: React.FC<GenericIomFormProps> = ({ assetContext = null }) 
         setIomTemplate(templateForEdit);
         setSubject(fetchedIom.subject);
         setDynamicFormData(fetchedIom.data_payload || {});
-        setInitialDataPayload(fetchedIom.data_payload || {});
+        // setInitialDataPayload(fetchedIom.data_payload || {}); // Removed
         setToUsersStr(fetchedIom.to_users?.join(',') || '');
         setToGroupsStr(fetchedIom.to_groups?.join(',') || '');
         setParentContentTypeId(fetchedIom.parent_content_type || null);
@@ -132,7 +132,7 @@ const GenericIomForm: React.FC<GenericIomFormProps> = ({ assetContext = null }) 
           }
         }
         setDynamicFormData(initialPayload);
-        setInitialDataPayload(initialPayload);
+         // setInitialDataPayload(initialPayload); // Removed
       } else {
         throw new Error("No Template ID for new IOM or IOM ID for editing.");
       }

--- a/itsm_frontend/src/modules/genericIom/types/genericIomTypes.ts
+++ b/itsm_frontend/src/modules/genericIom/types/genericIomTypes.ts
@@ -23,7 +23,7 @@ export interface GenericIOM {
   id: number;
   gim_id: string | null; // System-generated ID
   iom_template: number; // ID of the IOMTemplate
-  iom_template_details?: Pick<IOMTemplate, 'id' | 'name' | 'fields_definition' | 'approval_type'>; // Expanded details
+  iom_template_details?: Pick<IOMTemplate, 'id' | 'name' | 'fields_definition' | 'approval_type' | 'simple_approval_user' | 'simple_approval_group'>; // Expanded details
   subject: string;
   data_payload: IomDataPayload;
   status: GenericIomStatus;
@@ -75,7 +75,7 @@ export interface GetGenericIomsParams {
   page?: number;
   pageSize?: number;
   ordering?: string;
-  status?: GenericIomStatus | GenericIomStatus[];
+  status?: GenericIomStatus | GenericIomStatus[] | 'all_except_archived'; // Added 'all_except_archived'
   iom_template_id?: number;
   created_by_id?: number;
   search?: string; // For searching subject, gim_id, data_payload content

--- a/itsm_frontend/src/types/UserTypes.ts
+++ b/itsm_frontend/src/types/UserTypes.ts
@@ -10,5 +10,14 @@ export interface User {
   is_active: boolean;
   date_joined: string; // ISO 8601 string (e.g., "2025-06-09T17:47:28.175204Z")
   last_login: string | null; // ISO 8601 string or null
+  groups?: UserGroup[]; // User can belong to multiple groups
   // Add any other user profile fields your backend exposes (e.g., 'role', 'department')
+}
+
+// Define UserGroup if it's not already defined elsewhere (e.g., in a shared types file)
+// This is a common structure for group information linked to a user.
+export interface UserGroup {
+  id: number;
+  name: string;
+  // Add any other group fields if needed, e.g., 'permissions'
 }


### PR DESCRIPTION
This commit builds upon the previous fixes by:
- Updating type definitions for GenericIOM (iom_template_details pick) and User (adding groups property) to resolve cascading type errors in components.
- Ensuring related component code (GenericIomDetailComponent) correctly utilizes these updated types, removing previous casts.
- Modifying GetGenericIomsParams to correctly type the 'status' field for 'all_except_archived' values, removing a cast in GenericIomList.
- Changing FormFieldValue import to be type-only in GenericIomForm to comply with verbatimModuleSyntax.
- Ensuring full removal of setInitialDataPayload calls in GenericIomForm.

Investigated persistent ESLint errors for 'react/prop-types' and a TypeScript error for Vitest's 'toBe' matcher arguments, concluding they are likely environment/tooling setup issues as the relevant code and configurations appear correct.