### PR TITLE
Implement frontend for advanced Generic IOM approvals

### DIFF
--- a/itsm_frontend/src/modules/genericIom/types/genericIomTypes.ts
+++ b/itsm_frontend/src/modules/genericIom/types/genericIomTypes.ts
@@ -4,6 +4,7 @@
 // or imported into genericIomApi.ts from a shared location.
 
 import type { IOMTemplate } from '../../iomTemplateAdmin/types/iomTemplateAdminTypes'; // For nesting template details
+import type { ApprovalStep } from '../../procurement/types/procurementTypes'; // Added for advanced approval steps
 
 // Status choices for GenericIOM - should align with backend model
 export type GenericIomStatus =
@@ -51,7 +52,7 @@ export interface GenericIOM {
   simple_approval_comments?: string | null;
 
   // Placeholder for advanced approval steps if fetched/nested
-  // approval_steps?: any[];
+  approval_steps?: ApprovalStep[]; // Added for storing fetched approval steps for advanced workflows
 }
 
 // Data for creating a new GenericIOM


### PR DESCRIPTION
This commit introduces the UI and logic in `GenericIomDetailComponent.tsx` to support advanced, multi-step approval workflows for Generic IOMs.

Key changes:
- Fetches `ApprovalStep` data for IOMs using 'advanced' approval templates.
- Displays each approval step with details: order, rule name, assignee (user/group), status (with color-coded chip and icon), actioner, decision date, and comments.
- Provides 'Approve Step' and 'Reject Step' buttons for pending steps assigned to the current logged-in user.
- Uses a shared comment field for approval/rejection reasons.
- Calls backend APIs (`approveApprovalStep`, `rejectApprovalStep`) to action steps.
- Refreshes IOM and approval step data after actions.
- Updates frontend types (`GenericIOM` and `ApprovalStep`) to support this feature.

This addresses a key gap identified in the previous review, enabling users to interact with complex approval chains defined in the backend.