### PR TITLE
Enhance Dynamic Form Selectors for Generic IOMs

### DIFF
--- a/itsm_frontend/src/api/coreApi.ts
+++ b/itsm_frontend/src/api/coreApi.ts
@@ -58,3 +58,65 @@ export const getContentTypeId = async (
 //   const endpoint = `${API_CORE_BASE_PATH}/some-other-endpoint/`;
 //   return await authenticatedFetch(endpoint);
 // };
+
+// --- Group Types and Functions ---
+// Basic Group type for selection
+export interface AuthGroup {
+  id: number;
+  name: string;
+}
+
+// Placeholder for PaginatedResponse if not imported globally
+interface PaginatedGroupResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: AuthGroup[];
+}
+
+/**
+ * Fetches a list of authentication groups.
+ * TODO: This is a placeholder. A real backend endpoint (e.g., /api/core/groups/ or /api/auth/groups/)
+ * and corresponding Django View/Serializer for django.contrib.auth.models.Group are needed.
+ * @param authenticatedFetch The authenticated fetch function.
+ * @param searchOptional Optional search string for filtering group names.
+ * @param params Optional additional parameters like page, pageSize.
+ * @returns A Promise that resolves to a list of AuthGroup objects.
+ */
+export const getAuthGroups = async (
+  authenticatedFetch: AuthenticatedFetch,
+  search?: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  params?: { page?: number; pageSize?: number } // To match expected signature for GenericApiAutocomplete
+): Promise<PaginatedGroupResponse | AuthGroup[]> => { // To match GenericApiAutocomplete's expected return
+  // const queryParams = new URLSearchParams();
+  // if (search) queryParams.append('search', search);
+  // if (params?.page) queryParams.append('page', String(params.page));
+  // if (params?.pageSize) queryParams.append('page_size', String(params.pageSize));
+  // const endpoint = `${API_CORE_BASE_PATH}/groups/${queryParams.toString() ? '?' : ''}${queryParams.toString()}`;
+  // console.log(`Placeholder: Would fetch from ${endpoint}`);
+
+  // For now, returning a dummy response structure or an empty array.
+  // Replace with actual API call when backend endpoint is ready.
+  console.warn(
+    `getAuthGroups is using placeholder data. Backend endpoint required at /api/core/groups/ or similar for django.contrib.auth.models.Group. Search term: ${search}`
+  );
+
+  // Simulate a paginated response structure if your GenericApiAutocomplete expects it
+  // Otherwise, just return AuthGroup[]
+  const placeholderGroups: AuthGroup[] = [
+    // { id: 1, name: 'Admins (Placeholder)' },
+    // { id: 2, name: 'Editors (Placeholder)' }
+  ];
+
+  // If GenericApiAutocomplete handles both PaginatedResponse and T[], returning T[] is simpler for placeholder
+  // return placeholderGroups;
+
+  // If PaginatedResponse is strictly needed by GenericApiAutocomplete:
+   return Promise.resolve({
+     count: placeholderGroups.length,
+     next: null,
+     previous: null,
+     results: placeholderGroups,
+   });
+};

--- a/itsm_frontend/src/hooks/useDebounce.ts
+++ b/itsm_frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    // Update debounced value after delay
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Cancel the timeout if value changes (also on delay change or unmount)
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]); // Only re-call effect if value or delay changes
+
+  return debouncedValue;
+}

--- a/itsm_frontend/src/modules/genericIom/components/DynamicIomFormFieldRenderer.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/DynamicIomFormFieldRenderer.tsx
@@ -19,6 +19,17 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import type { FieldDefinition } from '../../iomTemplateAdmin/types/iomTemplateAdminTypes';
+import GenericApiAutocomplete from './GenericApiAutocomplete'; // Import the new component
+import { useAuth } from '../../../context/auth/useAuth'; // To pass authenticatedFetch
+import { getUserList } from '../../../api/authApi'; // API function for users
+import { getAssets } from '../../../api/assetApi'; // API function for assets
+import { getAuthGroups } from '../../../api/coreApi'; // API function for groups (placeholder)
+import { getDepartmentsForDropdown, getProjectsForDropdown } from '../../../api/procurementApi'; // API functions for departments and projects
+import type { User } from '../../../types/UserTypes'; // Type for User options
+import type { Asset } from '../../assets/types/assetTypes'; // Type for Asset options
+import type { AuthGroup } from '../../../api/coreApi'; // Type for Group options
+import type { Department, Project } from '../../procurement/types/procurementTypes'; // Types for Department & Project options
+import type { PaginatedResponse } from './GenericApiAutocomplete'; // Import PaginatedResponse if needed by fetch wrapper
 
 export type FormFieldValue = string | number | boolean | (string | number)[] | null | undefined;
 
@@ -37,6 +48,8 @@ const DynamicIomFormFieldRenderer: React.FC<DynamicFormFieldProps> = ({
   disabled = false,
   error = null,
 }) => {
+  const { authenticatedFetch } = useAuth(); // Get authenticatedFetch from context
+
   const commonProps = {
     name: field.name,
     label: field.label,
@@ -198,23 +211,175 @@ const DynamicIomFormFieldRenderer: React.FC<DynamicFormFieldProps> = ({
           );
         }
     case 'user_selector_single':
-    case 'user_selector_multiple':
-    case 'group_selector_single':
-    case 'group_selector_multiple':
-    case 'asset_selector_single':
-    case 'asset_selector_multiple':
-    case 'department_selector':
-    case 'project_selector':
+    case 'user_selector_multiple': {
+      const fetchUsers = async (
+        authFetch: typeof authenticatedFetch,
+        inputValue?: string,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _params?: Record<string, string|number> // Not using additional params for users for now
+      ): Promise<PaginatedResponse<User> | User[]> => {
+        // getUserList expects authenticatedFetch as its first argument.
+        // It might need to be adapted if it doesn't fit PaginatedResponse<User> directly or needs search.
+        // For now, assuming getUserList is compatible or we adapt its usage.
+        // If getUserList returns User[], wrap it or adjust GenericApiAutocomplete.
+        // Let's assume getUserList itself handles pagination and search if necessary,
+        // or we simplify for now and fetch all and let Autocomplete filter client-side.
+        // The `getUserList` in `authApi.ts` returns `Promise<User[]>` after extracting `results`.
+        // So, we directly return that.
+        const users = await getUserList(authFetch, { search: inputValue, page_size: 20 }); // Example: pass inputValue as search
+        return users; // This is User[]
+      };
+
       return (
-        <TextField
-          {...commonProps}
-          type={field.type.includes('multiple') ? 'text' : "number"}
-          value={value || field.defaultValue || ''}
-          placeholder={field.placeholder || (field.type.includes('multiple') ? 'Enter IDs comma-separated' : 'Enter ID')}
-          onChange={(e) => onChange(field.name, field.type.includes('multiple') ? e.target.value.split(',').map(s => s.trim()).filter(Boolean) : (e.target.value === '' ? null : Number(e.target.value)))}
-          helperText={error || field.helpText || `Placeholder for ${field.label}. API source: ${field.api_source?.endpoint || 'N/A'}`}
+        <GenericApiAutocomplete<User>
+          label={field.label}
+          value={value as number | number[] | null}
+          onChange={(newValue) => onChange(field.name, newValue)}
+          fetchOptionsApi={fetchUsers}
+          optionValueField="id"
+          optionLabelField={(option: User) => `${option.first_name} ${option.last_name} (${option.username})`}
+          multiple={field.type === 'user_selector_multiple'}
+          required={field.required}
+          disabled={disabled || field.readonly}
+          readOnly={field.readonly}
+          placeholder={field.placeholder || (field.type.includes('multiple') ? 'Select users' : 'Select user')}
+          helperText={error || field.helpText}
+          error={Boolean(error)}
+          authenticatedFetch={authenticatedFetch}
         />
       );
+    }
+    case 'asset_selector_single':
+    case 'asset_selector_multiple': {
+      const fetchAssets = async (
+        authFetch: typeof authenticatedFetch,
+        inputValue?: string,
+        apiParams?: Record<string, string|number>
+      ): Promise<PaginatedResponse<Asset> | Asset[]> => {
+        const params: import('../../assets/types/assetTypes').GetAssetsParams = {
+            filters: { search: inputValue || '' }, // Use search filter
+            pageSize: apiParams?.pageSize as number || 20,
+            // Add other necessary params like page if GenericApiAutocomplete handles pagination internally
+        };
+        const response = await getAssets(authFetch, params);
+        return response; // This is PaginatedResponse<Asset>
+      };
+
+      return (
+        <GenericApiAutocomplete<Asset>
+          label={field.label}
+          value={value as number | number[] | null}
+          onChange={(newValue) => onChange(field.name, newValue)}
+          fetchOptionsApi={fetchAssets}
+          optionValueField="id"
+          optionLabelField={(option: Asset) => `${option.asset_tag} - ${option.name}`}
+          multiple={field.type === 'asset_selector_multiple'}
+          required={field.required}
+          disabled={disabled || field.readonly}
+          readOnly={field.readonly}
+          placeholder={field.placeholder || (field.type.includes('multiple') ? 'Select assets' : 'Select asset')}
+          helperText={error || field.helpText}
+          error={Boolean(error)}
+          authenticatedFetch={authenticatedFetch}
+        />
+      );
+    }
+    case 'group_selector_single':
+    case 'group_selector_multiple': {
+      // Using the placeholder getAuthGroups from coreApi.ts
+      // This will show an empty list until the backend API is implemented.
+      const fetchGroups = async (
+        authFetch: typeof authenticatedFetch,
+        inputValue?: string,
+        apiParams?: Record<string, string|number>
+      ): Promise<PaginatedResponse<AuthGroup> | AuthGroup[]> => {
+        const response = await getAuthGroups(authFetch, inputValue, apiParams);
+        return response; // getAuthGroups currently returns PaginatedGroupResponse or AuthGroup[]
+      };
+
+      return (
+        <GenericApiAutocomplete<AuthGroup>
+          label={field.label}
+          value={value as number | number[] | null}
+          onChange={(newValue) => onChange(field.name, newValue)}
+          fetchOptionsApi={fetchGroups}
+          optionValueField="id"
+          optionLabelField="name" // AuthGroup has 'name' field
+          multiple={field.type === 'group_selector_multiple'}
+          required={field.required}
+          disabled={disabled || field.readonly}
+          readOnly={field.readonly}
+          placeholder={field.placeholder || (field.type.includes('multiple') ? 'Select groups' : 'Select group')}
+          helperText={error || field.helpText || "Group selector (requires backend API for actual data)"}
+          error={Boolean(error)}
+          authenticatedFetch={authenticatedFetch}
+        />
+      );
+    }
+    case 'department_selector': {
+      const fetchDepartments = async (
+        authFetch: typeof authenticatedFetch,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        inputValue?: string, // Departments list is usually not searched via free text for now
+        apiParams?: Record<string, string|number>
+      ): Promise<PaginatedResponse<Department> | Department[]> => {
+        // getDepartmentsForDropdown returns PaginatedResponse<Department>
+        // No specific search input for now, fetches all (up to page_size in API)
+        const response = await getDepartmentsForDropdown(authFetch /*, { pageSize: apiParams?.pageSize as number || 200 } */); // pageSize is hardcoded in API
+        return response;
+      };
+
+      return (
+        <GenericApiAutocomplete<Department>
+          label={field.label}
+          value={value as number | null} // Assuming single select for department
+          onChange={(newValue) => onChange(field.name, newValue)}
+          fetchOptionsApi={fetchDepartments}
+          optionValueField="id"
+          optionLabelField={(option: Department) => `${option.name} ${option.department_code ? `(${option.department_code})` : ''}`}
+          multiple={false} // Department selector is single
+          required={field.required}
+          disabled={disabled || field.readonly}
+          readOnly={field.readonly}
+          placeholder={field.placeholder || 'Select department'}
+          helperText={error || field.helpText}
+          error={Boolean(error)}
+          authenticatedFetch={authenticatedFetch}
+          // No server-side search for departments yet, Autocomplete will filter client-side
+        />
+      );
+    }
+    case 'project_selector': {
+      const fetchProjects = async (
+        authFetch: typeof authenticatedFetch,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        inputValue?: string, // Projects list is usually not searched via free text for now
+        apiParams?: Record<string, string|number>
+      ): Promise<PaginatedResponse<Project> | Project[]> => {
+        // getProjectsForDropdown returns PaginatedResponse<Project>
+        const response = await getProjectsForDropdown(authFetch /*, { pageSize: apiParams?.pageSize as number || 200 } */); // pageSize is hardcoded in API
+        return response;
+      };
+
+      return (
+        <GenericApiAutocomplete<Project>
+          label={field.label}
+          value={value as number | null} // Assuming single select for project
+          onChange={(newValue) => onChange(field.name, newValue)}
+          fetchOptionsApi={fetchProjects}
+          optionValueField="id"
+          optionLabelField={(option: Project) => `${option.name} ${option.project_code ? `(${option.project_code})` : ''}`}
+          multiple={false} // Project selector is single
+          required={field.required}
+          disabled={disabled || field.readonly}
+          readOnly={field.readonly}
+          placeholder={field.placeholder || 'Select project'}
+          helperText={error || field.helpText}
+          error={Boolean(error)}
+          authenticatedFetch={authenticatedFetch}
+        />
+      );
+    }
     case 'file_upload': {
         return (
             <TextField

--- a/itsm_frontend/src/modules/genericIom/components/GenericApiAutocomplete.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/GenericApiAutocomplete.tsx
@@ -1,0 +1,217 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { Autocomplete, TextField, CircularProgress, Chip } from '@mui/material';
+import type { AuthenticatedFetch } from '../../../context/auth/AuthContextDefinition'; // Adjust path as needed
+import { useDebounce } from '../../../hooks/useDebounce'; // Assuming a debounce hook exists or will be created
+
+// Generic type for API response items
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface ApiOptionType extends Record<string, any> {
+  // Ensure id is present, but allow any other fields
+  id: number;
+}
+
+export interface PaginatedResponse<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}
+
+
+interface GenericApiAutocompleteProps<T extends ApiOptionType> {
+  label: string;
+  value: number | number[] | null; // Selected ID or array of IDs
+  onChange: (newValue: number | number[] | null) => void;
+  fetchOptionsApi: (
+    authenticatedFetch: AuthenticatedFetch,
+    inputValue?: string,
+    params?: Record<string, string | number> // For additional fixed params like page_size
+  ) => Promise<PaginatedResponse<T> | T[]>; // API function can return paginated or direct array
+  optionValueField: keyof T | 'id'; // Key for the ID in fetched option objects, defaults to 'id'
+  optionLabelField: keyof T | ((option: T) => string); // Key for the display label or a function to derive it
+
+  multiple?: boolean;
+  required?: boolean;
+  disabled?: boolean;
+  readOnly?: boolean;
+  placeholder?: string;
+  helperText?: string;
+  error?: boolean;
+  authenticatedFetch: AuthenticatedFetch;
+
+  // For Autocomplete's getOptionLabel, if more complex than just accessing a field
+  getOptionLabelOverride?: (option: T) => string;
+  // For Autocomplete's isOptionEqualToValue, crucial if `value` prop is an object
+  isOptionEqualToValueOverride?: (option: T, value: T) => boolean;
+
+  initialOptions?: T[]; // Allow passing initial options to avoid fetch on mount if data is already available
+  fetchDelay?: number; // Debounce delay for fetching options based on input
+  additionalApiParams?: Record<string, string | number>; // To pass fixed params like page_size to fetchOptionsApi
+}
+
+function GenericApiAutocomplete<T extends ApiOptionType>({
+  label,
+  value,
+  onChange,
+  fetchOptionsApi,
+  optionValueField = 'id',
+  optionLabelField,
+  multiple = false,
+  required = false,
+  disabled = false,
+  readOnly = false,
+  placeholder,
+  helperText,
+  error,
+  authenticatedFetch,
+  getOptionLabelOverride,
+  isOptionEqualToValueOverride,
+  initialOptions = [],
+  fetchDelay = 300,
+  additionalApiParams = { pageSize: 20 } // Default page size
+}: GenericApiAutocompleteProps<T>) {
+  const [open, setOpen] = useState(false);
+  const [options, setOptions] = useState<readonly T[]>(initialOptions);
+  const [loading, setLoading] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const debouncedInputValue = useDebounce(inputValue, fetchDelay);
+
+  const getOptionLabel = (option: T | string): string => {
+    if (typeof option === 'string') return option; // For freeSolo or when input is not an option yet
+    if (getOptionLabelOverride) return getOptionLabelOverride(option);
+    if (typeof optionLabelField === 'function') return optionLabelField(option);
+    return String(option[optionLabelField] || '');
+  };
+
+  const isOptionEqualToValue = (option: T, val: T): boolean => {
+    if (isOptionEqualToValueOverride) return isOptionEqualToValueOverride(option, val);
+    return option[optionValueField] === val[optionValueField];
+  };
+
+  useEffect(() => {
+    let active = true;
+
+    if (!open && initialOptions.length === 0) { // Don't clear options if provided initially and not open
+      // setOptions([]); // Clear options when dropdown is closed to re-fetch next time, unless initialOptions were provided
+      return undefined;
+    }
+
+    // Only fetch if open and (input has changed for server-side search OR options are empty)
+    // For server-side search, debouncedInputValue will trigger this.
+    // For client-side search on initial open, options.length === 0 will trigger.
+    if (!open && !debouncedInputValue && options.length > 0 && initialOptions.length > 0) {
+        // If not open, no input, and we have initial options, do nothing.
+        return undefined;
+    }
+
+
+    (async () => {
+      setLoading(true);
+      try {
+        // Pass debouncedInputValue for server-side filtering if API supports it
+        const response = await fetchOptionsApi(authenticatedFetch, debouncedInputValue, additionalApiParams);
+        if (active) {
+          const newOptions = Array.isArray(response) ? response : response.results;
+          setOptions(newOptions);
+        }
+      } catch (apiError) {
+        console.error(`Failed to fetch options for ${label}:`, apiError);
+        // Optionally set an error state to display to the user
+        setOptions([]); // Clear options on error
+      }
+      setLoading(false);
+    })();
+
+    return () => {
+      active = false;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedInputValue, open, authenticatedFetch, fetchOptionsApi, label, initialOptions.length > 0 ? null : fetchDelay]); // Re-fetch if fetchOptionsApi changes, or if dropdown opens with no initial options.
+
+
+  // Memoize the selected value(s) in the format Autocomplete expects (full option objects)
+  const selectedValueOrValues = useMemo(() => {
+    if (multiple) {
+      if (!Array.isArray(value)) return [];
+      return options.filter(option => (value as number[]).includes(option[optionValueField] as number));
+    }
+    if (value === null || value === undefined) return null;
+    return options.find(option => option[optionValueField] === value) || null;
+  }, [value, options, multiple, optionValueField]);
+
+  const handleChange = (_event: React.SyntheticEvent, newValue: T | T[] | null) => {
+    if (readOnly) return;
+    if (multiple) {
+      const newIds = (newValue as T[]).map(option => option[optionValueField] as number);
+      onChange(newIds.length > 0 ? newIds : null);
+    } else {
+      onChange(newValue ? (newValue as T)[optionValueField] as number : null);
+    }
+  };
+
+  return (
+    <Autocomplete<T, typeof multiple, undefined, false> // `false` for freeSolo not enabled by default
+      multiple={multiple}
+      open={open}
+      onOpen={() => {
+        if (readOnly || disabled) return;
+        setOpen(true);
+      }}
+      onClose={() => {
+        setOpen(false);
+      }}
+      value={selectedValueOrValues as typeof multiple extends true ? T[] : T | null} // Type assertion
+      onChange={handleChange}
+      options={options}
+      loading={loading}
+      isOptionEqualToValue={isOptionEqualToValue}
+      getOptionLabel={getOptionLabel}
+      onInputChange={(_event, newInputValue) => {
+        if (readOnly || disabled) return;
+        setInputValue(newInputValue);
+      }}
+      disabled={disabled || readOnly}
+      readOnly={readOnly} // Pass readOnly to Autocomplete
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          required={required}
+          placeholder={placeholder}
+          helperText={helperText}
+          error={error}
+          InputProps={{
+            ...params.InputProps,
+            readOnly: readOnly, // Also apply to TextField's input element
+            endAdornment: (
+              <>
+                {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+        />
+      )}
+      renderOption={(props, option, { selected }) => (
+        <li {...props}>
+          {multiple && <Checkbox checked={selected} style={{ marginRight: 8 }} />}
+          {getOptionLabel(option)}
+        </li>
+      )}
+      renderTags={multiple ? (tagValue, getTagProps) =>
+        tagValue.map((option, index) => (
+          <Chip
+            label={getOptionLabel(option)}
+            {...getTagProps({ index })}
+            disabled={disabled || readOnly}
+          />
+        )) : undefined
+      }
+      // sx={readOnly ? { backgroundColor: 'action.disabledBackground', pointerEvents: 'none'} : {}}
+      // The disabled prop on Autocomplete should handle pointerEvents.
+      // TextField's InputProps.readOnly will make the text field non-editable.
+    />
+  );
+}
+
+export default GenericApiAutocomplete;


### PR DESCRIPTION
This commit replaces plain text input fields for ID entry with interactive Autocomplete selectors for various field types in the Generic IOM dynamic forms.

Key changes:
- Created a reusable `GenericApiAutocomplete.tsx` component capable of fetching options from an API, supporting single/multiple selections, and debounced input.
- Created a `useDebounce.ts` hook.
- Updated `DynamicIomFormFieldRenderer.tsx` to use `GenericApiAutocomplete` for:
  - `user_selector_single` & `user_selector_multiple` (uses `getUserList` API).
  - `asset_selector_single` & `asset_selector_multiple` (uses `getAssets` API with search).
  - `group_selector_single` & `group_selector_multiple` (uses a placeholder `getAuthGroups` API; backend endpoint for listing groups is a prerequisite for full functionality).
  - `department_selector` (uses `getDepartmentsForDropdown` API).
  - `project_selector` (uses `getProjectsForDropdown` API).
- This significantly improves the user experience when filling out IOM forms that require selecting users, assets, groups, departments, or projects.