### PR TITLE
Implement backend API for Groups and integrate with frontend selector

### DIFF
--- a/core_api/serializers.py
+++ b/core_api/serializers.py
@@ -1,7 +1,13 @@
 from rest_framework import serializers
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth.models import Group
 
 class ContentTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = ContentType
         fields = ['id', 'app_label', 'model']
+
+class GroupSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Group
+        fields = ['id', 'name']

--- a/core_api/urls.py
+++ b/core_api/urls.py
@@ -1,11 +1,19 @@
 # itsm_project/core_api/urls.py
 
-from django.urls import path
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
 from . import views
 
 app_name = 'core_api'  # Added for namespacing
 
+# Create a router and register our viewsets with it.
+router = DefaultRouter()
+router.register(r'groups', views.GroupViewSet, basename='group')
+# router.register(r'contenttypes', views.ContentTypeViewSet, basename='contenttype') # If ContentTypeViewSet was used instead of APIView
+
 urlpatterns = [
     path("hello/", views.hello_world, name="hello_world"),
     path("contenttypes/get-id/", views.ContentTypeLookupView.as_view(), name="contenttype-get-id"),
+    # The API URLs are now determined automatically by the router.
+    path('', include(router.urls)),
 ]

--- a/core_api/views.py
+++ b/core_api/views.py
@@ -3,9 +3,10 @@
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework import status
+from rest_framework import status, viewsets, filters
 from django.contrib.contenttypes.models import ContentType
-from .serializers import ContentTypeSerializer
+from django.contrib.auth.models import Group
+from .serializers import ContentTypeSerializer, GroupSerializer
 from rest_framework.permissions import IsAuthenticated
 
 
@@ -46,3 +47,14 @@ class ContentTypeLookupView(APIView):
                 {"error": f"An unexpected error occurred: {str(e)}"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
+
+class GroupViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    A ViewSet for listing and retrieving user groups.
+    Supports searching by group name.
+    """
+    queryset = Group.objects.all().order_by('name')
+    serializer_class = GroupSerializer
+    permission_classes = [IsAuthenticated]
+    filter_backends = [filters.SearchFilter]
+    search_fields = ['name']


### PR DESCRIPTION
This commit introduces a backend API endpoint to list and search Django auth Groups and updates the frontend to use this API for group selector fields in Generic IOM forms.

Backend changes (in `core_api` app):
- Added `GroupSerializer` to serialize `Group` model (id, name).
- Added `GroupViewSet` (ReadOnlyModelViewSet) with search on `name` field and `IsAuthenticated` permission.
- Registered `/groups/` URL route for the `GroupViewSet`.

Frontend changes:
- Updated `getAuthGroups` function in `itsm_frontend/src/api/coreApi.ts` to call the new `/api/core/groups/` endpoint, replacing placeholder logic.
- The `DynamicIomFormFieldRenderer.tsx` for `group_selector_single` and `group_selector_multiple` types will now use this live data via the `GenericApiAutocomplete` component.

This enables functional group selection in IOM dynamic forms, resolving a key prerequisite for enhanced form usability.