### PR TITLE
Implement auto-population for 'FROM' fields in Generic IOMs

### DIFF
--- a/itsm_frontend/src/types/UserTypes.ts
+++ b/itsm_frontend/src/types/UserTypes.ts
@@ -11,7 +11,9 @@ export interface User {
   date_joined: string; // ISO 8601 string (e.g., "2025-06-09T17:47:28.175204Z")
   last_login: string | null; // ISO 8601 string or null
   groups?: UserGroup[]; // User can belong to multiple groups
-  // Add any other user profile fields your backend exposes (e.g., 'role', 'department')
+  department_id?: number | null; // Added for user's department
+  department_name?: string | null; // Added for user's department name
+  // Add any other user profile fields your backend exposes (e.g., 'role')
 }
 
 // Define UserGroup if it's not already defined elsewhere (e.g., in a shared types file)


### PR DESCRIPTION
This commit introduces functionality to auto-populate fields representing the sender's department and name in Generic IOM forms based on the logged-in user's context.

Key changes:
- Updated frontend `User` type (`UserTypes.ts`) and `loginApi` (`authApi.ts`) to expect and handle `department_id` and `department_name` for the user. (Note: Backend User serializer must be updated to provide this data for full functionality).
- Modified `GenericIomForm.tsx` in create mode:
  - If an IOM template's `fields_definition` contains fields with conventional names like 'from_department', 'sender_department', 'from_user', or 'sender_user_name', these fields will be pre-filled with the logged-in user's department name or full name, respectively, if available in the auth context.
  - This auto-population respects existing `defaultValue`s (currently, it won't override if a `defaultValue` results in the field not being `undefined`).
- Read-only behavior for these auto-populated fields is controlled by the `readonly` property in the IOM template's `FieldDefinition`.

This enhancement improves form efficiency by reducing manual data entry for sender information in IOMs.