### PR TITLE
Transition PRM to GenericIOM: Phases 1 & Initial Frontend/Backend Prep

### DIFF
--- a/procurement/models.py
+++ b/procurement/models.py
@@ -215,8 +215,18 @@ class PurchaseOrder(models.Model):
         PurchaseRequestMemo,
         on_delete=models.SET_NULL,
         null=True, blank=True,
-        related_name='purchase_order',
-        verbose_name=_("Internal Office Memo")
+        related_name='purchase_order_legacy', # Changed related_name to avoid clash if we rename or reuse
+        verbose_name=_("Original Purchase Request Memo (Legacy)")
+    )
+    # New field to link to GenericIOM based Purchase Requests
+    generic_iom_purchase_request = models.ForeignKey(
+        'generic_iom.GenericIOM',
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='purchase_orders_via_generic_iom',
+        verbose_name=_("Generic IOM Purchase Request"),
+        help_text=_("Link to the Generic IOM that represents the purchase request, if applicable.")
     )
     vendor = models.ForeignKey(
         Vendor,

--- a/procurement/serializers.py
+++ b/procurement/serializers.py
@@ -23,6 +23,12 @@ from generic_iom.models import IOMTemplate, IOMCategory, GenericIOM
 
 User = get_user_model()
 
+# A simple serializer for GenericIOM to be nested in PurchaseOrderSerializer
+class SimpleGenericIOMSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GenericIOM
+        fields = ['id', 'gim_id', 'subject', 'status'] # Basic info
+
 # Serializers for Common Models (basic, can be expanded)
 class DepartmentSerializer(serializers.ModelSerializer):
     class Meta:
@@ -119,7 +125,8 @@ class PurchaseOrderSerializer(serializers.ModelSerializer):
     order_items = OrderItemSerializer(many=True, required=False) # Not required if order_items_json is used
     vendor_details = VendorSerializer(source='vendor', read_only=True) # Assuming VendorSerializer exists and is suitable
     created_by_username = serializers.CharField(source='created_by.username', read_only=True)
-    internal_office_memo_details = PurchaseRequestMemoSerializer(source='internal_office_memo', read_only=True)
+    internal_office_memo_details = PurchaseRequestMemoSerializer(source='internal_office_memo', read_only=True, allow_null=True)
+    generic_iom_purchase_request_details = SimpleGenericIOMSerializer(source='generic_iom_purchase_request', read_only=True, allow_null=True)
     related_contract_details = serializers.StringRelatedField(source='related_contract', read_only=True)
     # For handling JSON string input for order items, e.g. from multipart forms
     order_items_json = serializers.CharField(write_only=True, required=False, allow_blank=True, help_text="JSON string of order items.")
@@ -129,7 +136,8 @@ class PurchaseOrderSerializer(serializers.ModelSerializer):
         model = PurchaseOrder
         fields = [
             'id', 'po_number',
-            'internal_office_memo', 'internal_office_memo_details',
+            'internal_office_memo', 'internal_office_memo_details', # Legacy PRM link
+            'generic_iom_purchase_request', 'generic_iom_purchase_request_details', # New GenericIOM PRM link
             'vendor', 'vendor_details',
             'order_date', 'expected_delivery_date',
             'total_amount', 'status',
@@ -144,7 +152,7 @@ class PurchaseOrderSerializer(serializers.ModelSerializer):
             'po_number', # Assuming system-generated
             'total_amount', # Calculated
             'created_by_username', 'created_at', 'updated_at',
-            'vendor_details', 'internal_office_memo_details', 'related_contract_details'
+            'vendor_details', 'internal_office_memo_details', 'generic_iom_purchase_request_details', 'related_contract_details'
         ]
         # `created_by` is typically set in the view.
 


### PR DESCRIPTION
This commit implements the initial phases for transitioning Purchase Request Memos (PRM) to use the Generic IOM system.

Phase 1 (Preparation & Template Creation):
- Added a 'Purchase Request' IOMTemplate definition to the data migration (`0003_load_sample_iom_templates.py`). This template is configured for 'advanced' approval and its `fields_definition` mirrors the fields of the legacy `PurchaseRequestMemo` model.

Phase 2 (Frontend UI Transition - Initial Steps):
- Updated `PurchaseRequestMemoList.tsx` to fetch the ID of the new 'Purchase Request' IOMTemplate.
- Modified the 'Create New Request' button to navigate to the `GenericIomFormPage`, passing this template ID, thus routing new PRM creation to the Generic IOM system.
- The old `PurchaseRequestMemoForm.tsx` is no longer used for creating new PRMs but remains for editing historical records.

Phase 3 (Backend Model & Data Considerations - Initial Steps):
- Added a new nullable ForeignKey `generic_iom_purchase_request` from the `PurchaseOrder` model to `GenericIOM` to allow linking POs to new GenericIOM-based purchase requests.
- Updated `PurchaseOrderSerializer` to include this new field.
- Data migration for existing `PurchaseRequestMemo` records is deferred.
- Attachment handling for new PRMs via GenericIOM will use a text description field for now.

This work enables new Purchase Requests to be created as GenericIOMs, using the dynamic template system. Full data migration and UI updates for Purchase Order linking will be subsequent phases.