### PR TITLE
Fix: Address second batch of frontend TypeScript/ESLint errors

### DIFF
--- a/itsm_frontend/src/App.test.tsx
+++ b/itsm_frontend/src/App.test.tsx
@@ -65,7 +65,7 @@ describe('App.tsx Routing and Authentication', () => {
   it('renders HomePage for "/" when authenticated', async () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
-      user: { id: 1, name: 'Test User', role: 'user', is_staff: false, groups:[] },
+      user: { id: 1, name: 'Test User', email: 'test@example.com', role: 'user', is_staff: false, groups:[] },
       token: 'fake-token',
       loading: false,
       login: vi.fn(),
@@ -90,7 +90,7 @@ describe('App.tsx Routing and Authentication', () => {
   });
 
   it('renders the protected route component when authenticated', async () => {
-    mockUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: 1, name: 'Test User', role: 'user', is_staff: false, groups:[] }, token: 'fake-token', loading: false, login: vi.fn(), logout: vi.fn(), authenticatedFetch: vi.fn() });
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: 1, name: 'Test User', email: 'test@example.com', role: 'user', is_staff: false, groups:[] }, token: 'fake-token', loading: false, login: vi.fn(), logout: vi.fn(), authenticatedFetch: vi.fn() });
     renderApp(['/assets']); // Example protected route
     await waitFor(() => expect(screen.getByText('AssetsPageMock')).toBeInTheDocument());
   });

--- a/itsm_frontend/src/api/coreApi.ts
+++ b/itsm_frontend/src/api/coreApi.ts
@@ -39,7 +39,7 @@ export const getContentTypeId = async (
     }
     console.error('getContentTypeId: Unexpected response structure:', response);
     return null; // Or throw a more specific error
-  } catch (error: any) {
+  } catch (error: unknown) {
     // API client's authenticatedFetch might throw for non-2xx responses.
     // If the error is a 404, we can specifically return null.
     // This depends on how authenticatedFetch and apiClient handle errors.

--- a/itsm_frontend/src/modules/assets/components/AssetForm.test.tsx
+++ b/itsm_frontend/src/modules/assets/components/AssetForm.test.tsx
@@ -84,7 +84,7 @@ describe('AssetForm', () => {
 
     vi.mocked(useAuthHook.useAuth).mockReturnValue({
       token: 'mockToken',
-      user: { id: 1, name: 'currentuser', role: 'user', is_staff: false, groups: [] },
+      user: { id: 1, name: 'currentuser', email: 'current@example.com', role: 'user', is_staff: false, groups: [] },
       authenticatedFetch: vi.fn(async (url, options) => {
         const res = await window.fetch(url, options);
         return res.json();

--- a/itsm_frontend/src/modules/assets/components/AssetList.test.tsx
+++ b/itsm_frontend/src/modules/assets/components/AssetList.test.tsx
@@ -56,7 +56,7 @@ const mockAssetsResponse: PaginatedResponse<Asset> = {
       warranty_end_date: '2026-01-01',
       serial_number: 'SER001',
       vendor: {id: 1, name: 'Vendor X'},
-      vendor_name: 'Vendor X',
+      // vendor_name: 'Vendor X', // Removed: name is in vendor object
       description: 'Test asset 1',
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
@@ -75,7 +75,7 @@ const mockAssetsResponse: PaginatedResponse<Asset> = {
       warranty_end_date: '2026-02-01',
       serial_number: 'SER002',
       vendor: {id: 2, name: 'Vendor Y'},
-      vendor_name: 'Vendor Y',
+      // vendor_name: 'Vendor Y', // Removed: name is in vendor object
       description: 'Test asset 2',
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),

--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
@@ -81,12 +81,11 @@ describe('CheckRequestList', () => {
       showSnackbar: vi.fn(),
       showConfirmDialog: vi.fn(),
       hideConfirmDialog: vi.fn(),
-      confirmDialogOpen: false, // Corrected property name
-      confirmDialogConfig: null, // Assuming this is the correct structure based on UIContext.ts
-      // confirmDialogTitle: '', // Add other properties if needed by the component
-      // confirmDialogMessage: '',
-      // confirmDialogOnConfirm: vi.fn(),
-      // confirmDialogOnCancel: vi.fn(),
+      confirmDialogOpen: false,
+      confirmDialogTitle: '',
+      confirmDialogMessage: '',
+      confirmDialogOnConfirm: vi.fn(),
+      confirmDialogOnCancel: undefined, // Match the type explicitly
     });
 
     vi.mocked(procurementApi.getCheckRequests).mockResolvedValue(mockPaginatedCRsResponse);

--- a/itsm_frontend/src/modules/procurement/components/purchase-orders/PurchaseOrderList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-orders/PurchaseOrderList.test.tsx
@@ -61,7 +61,7 @@ const mockEmptyPOsResponse: PaginatedResponse<PurchaseOrder> = {
   results: [],
 };
 
-const mockUser = { id: 1, name: 'Test User', role: 'admin', is_staff: true, groups: [] };
+const mockUser = { id: 1, name: 'Test User', email: 'test@example.com', role: 'admin', is_staff: true, groups: [] };
 
 describe('PurchaseOrderList', () => {
   beforeEach(() => {
@@ -81,12 +81,11 @@ describe('PurchaseOrderList', () => {
       showSnackbar: vi.fn(),
       showConfirmDialog: vi.fn(),
       hideConfirmDialog: vi.fn(),
-      confirmDialogOpen: false, // Corrected property name
-      confirmDialogConfig: null, // Assuming this is the correct structure
-      // confirmDialogTitle: '', // Add other properties if needed by the component
-      // confirmDialogMessage: '',
-      // confirmDialogOnConfirm: vi.fn(),
-      // confirmDialogOnCancel: vi.fn(),
+      confirmDialogOpen: false,
+      confirmDialogTitle: '',
+      confirmDialogMessage: '',
+      confirmDialogOnConfirm: vi.fn(),
+      confirmDialogOnCancel: undefined,
     });
 
     // Default API mock for getPurchaseOrders

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
@@ -123,13 +123,11 @@ describe('PurchaseRequestMemoList', () => {
       showSnackbar: vi.fn(),
       showConfirmDialog: vi.fn(),
       hideConfirmDialog: vi.fn(),
-      confirmDialogOpen: false, // Corrected property name
-      confirmDialogConfig: null, // Assuming this is the correct structure
-      // Add other confirmDialog properties if they are accessed by the component from the context
-      // confirmDialogTitle: '',
-      // confirmDialogMessage: '',
-      // confirmDialogOnConfirm: vi.fn(),
-      // confirmDialogOnCancel: vi.fn(),
+      confirmDialogOpen: false,
+      confirmDialogTitle: '',
+      confirmDialogMessage: '',
+      confirmDialogOnConfirm: vi.fn(),
+      confirmDialogOnCancel: undefined,
     });
 
     // IMPORTANT: Do not set a global .mockResolvedValue for getPurchaseRequestMemos here
@@ -414,8 +412,8 @@ describe('PurchaseRequestMemoList', () => {
       requested_by: 1,
     };
 
-    const mockUserRegular = { id: 2, name: 'regularJoe', role: 'user', is_staff: false, groups: [] };
-    const mockUserStaff = { id: 1, name: 'testuser', role: 'admin', is_staff: true, groups: [] };
+    const mockUserRegular = { id: 2, name: 'regularJoe', email: 'regular@example.com', role: 'user', is_staff: false, groups: [] };
+    const mockUserStaff = { id: 1, name: 'testuser', email: 'teststaff@example.com', role: 'admin', is_staff: true, groups: [] };
 
 
     it('shows Edit button for pending memo if user is requester, and navigates on click', async () => {
@@ -495,12 +493,15 @@ describe('PurchaseRequestMemoList', () => {
         user: { ...mockUserStaff, id: pendingMemoIsRequester.requested_by }, // User is requester
         isAuthenticated: true,
       });
-       vi.mocked(useUIHook.useUI).mockReturnValue({ // Assuming useUI is the hook name
+       vi.mocked(useUIHook.useUI).mockReturnValue({
         showSnackbar: vi.fn(),
         showConfirmDialog: mockShowConfirmDialog,
-        hideConfirmDialog: vi.fn(), // Added hideConfirmDialog
-        isConfirmDialogVisible: false, // Added isConfirmDialogVisible
-        confirmDialogConfig: null, // Added confirmDialogConfig
+        hideConfirmDialog: vi.fn(),
+        confirmDialogOpen: false,
+        confirmDialogTitle: '',
+        confirmDialogMessage: '',
+        confirmDialogOnConfirm: vi.fn(),
+        confirmDialogOnCancel: undefined,
       });
       const getMemosMock = vi.mocked(procurementApi.getPurchaseRequestMemos)
         .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: [pendingMemoIsRequester] }) // Initial load
@@ -532,8 +533,11 @@ describe('PurchaseRequestMemoList', () => {
             showSnackbar: vi.fn(),
             showConfirmDialog: mockShowConfirmDialog,
             hideConfirmDialog: vi.fn(),
-            isConfirmDialogVisible: false,
-            confirmDialogConfig: null,
+            confirmDialogOpen: false,
+            confirmDialogTitle: '',
+            confirmDialogMessage: '',
+            confirmDialogOnConfirm: vi.fn(),
+            confirmDialogOnCancel: undefined,
         });
         const getMemosMock = vi.mocked(procurementApi.getPurchaseRequestMemos)
             .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: [pendingMemoNotRequester] }) // Initial load
@@ -586,8 +590,11 @@ describe('PurchaseRequestMemoList', () => {
         showSnackbar: vi.fn(),
         showConfirmDialog: mockShowConfirmDialog,
         hideConfirmDialog: vi.fn(),
-        isConfirmDialogVisible: false,
-        confirmDialogConfig: null,
+        confirmDialogOpen: false,
+        confirmDialogTitle: '',
+        confirmDialogMessage: '',
+        confirmDialogOnConfirm: vi.fn(),
+        confirmDialogOnCancel: undefined,
       });
       vi.mocked(procurementApi.getPurchaseRequestMemos).mockResolvedValue({
         count: 1, next: null, previous: null, results: [pendingMemoIsRequester],

--- a/itsm_frontend/src/modules/service-requests/components/ServiceRequestForm.test.tsx
+++ b/itsm_frontend/src/modules/service-requests/components/ServiceRequestForm.test.tsx
@@ -82,13 +82,14 @@ describe('ServiceRequestForm.tsx', () => {
       login: vi.fn(),logout: vi.fn(), loading: false, isAuthenticated: true,
     });
     vi.mocked(useUIHook.useUI).mockReturnValue({
-      showSnackbar: vi.fn(), showConfirmDialog: vi.fn(), hideConfirmDialog: vi.fn(),
-      confirmDialogOpen: false, // Corrected property name
-      confirmDialogConfig: null, // Assuming this is the correct structure
-      // confirmDialogTitle: '', // Add other properties if needed
-      // confirmDialogMessage: '',
-      // confirmDialogOnConfirm: vi.fn(),
-      // confirmDialogOnCancel: vi.fn(),
+      showSnackbar: vi.fn(),
+      showConfirmDialog: vi.fn(),
+      hideConfirmDialog: vi.fn(),
+      confirmDialogOpen: false,
+      confirmDialogTitle: '',
+      confirmDialogMessage: '',
+      confirmDialogOnConfirm: vi.fn(),
+      confirmDialogOnCancel: undefined,
     });
     vi.mocked(assetApi.getAssetCategories).mockResolvedValue(mockCategories);
     vi.mocked(serviceRequestApi.createServiceRequest).mockResolvedValue({ id: 123, request_id: 'SR-NEW-123' } as ServiceRequest);

--- a/itsm_frontend/src/modules/service-requests/pages/ServiceRequestsPage.test.tsx
+++ b/itsm_frontend/src/modules/service-requests/pages/ServiceRequestsPage.test.tsx
@@ -98,7 +98,7 @@ const mockEmptySRsResponse: PaginatedResponse<ServiceRequest> = {
   results: [],
 };
 
-const mockUser = { id: 1, name: 'Test User', role: 'admin', is_staff: true, groups: [] };
+const mockUser = { id: 1, name: 'Test User', email: 'test@example.com', role: 'admin', is_staff: true, groups: [] }; // Added email
 
 describe('ServiceRequestsPage.tsx', () => {
   beforeEach(() => {
@@ -106,7 +106,7 @@ describe('ServiceRequestsPage.tsx', () => {
 
     vi.mocked(useAuthHook.useAuth).mockReturnValue({
       token: 'mockToken',
-      user: mockUser,
+      user: mockUser, // mockUser now includes email
       authenticatedFetch: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
       login: vi.fn(),
       logout: vi.fn(),
@@ -118,12 +118,11 @@ describe('ServiceRequestsPage.tsx', () => {
       showSnackbar: vi.fn(),
       showConfirmDialog: vi.fn(),
       hideConfirmDialog: vi.fn(),
-      confirmDialogOpen: false, // Corrected property name
-      confirmDialogConfig: null, // Assuming this is the correct structure
-      // confirmDialogTitle: '', // Add other properties if needed
-      // confirmDialogMessage: '',
-      // confirmDialogOnConfirm: vi.fn(),
-      // confirmDialogOnCancel: vi.fn(),
+      confirmDialogOpen: false,
+      confirmDialogTitle: '',
+      confirmDialogMessage: '',
+      confirmDialogOnConfirm: vi.fn(),
+      confirmDialogOnCancel: undefined,
     });
 
     vi.mocked(serviceRequestApi.getServiceRequests).mockResolvedValue(mockPaginatedSRsResponse);
@@ -137,7 +136,6 @@ describe('ServiceRequestsPage.tsx', () => {
 
   it('renders table headers correctly', async () => {
     renderServiceRequestsPage();
-    // Wait for data to load as headers are part of DataGrid which renders after data fetch
     await waitFor(() => expect(serviceRequestApi.getServiceRequests).toHaveBeenCalledTimes(1));
 
     expect(screen.getByText('Request ID')).toBeInTheDocument();
@@ -146,10 +144,10 @@ describe('ServiceRequestsPage.tsx', () => {
     expect(screen.getByText('Category')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
     expect(screen.getByText('Priority')).toBeInTheDocument();
-    expect(screen.getByText('Requested By')).toBeInTheDocument(); // Changed from Reported By
+    expect(screen.getByText('Requested By')).toBeInTheDocument();
     expect(screen.getByText('Assigned To')).toBeInTheDocument();
     expect(screen.getByText('Created At')).toBeInTheDocument();
-    expect(screen.getByText('Last Updated')).toBeInTheDocument(); // Added
+    expect(screen.getByText('Last Updated')).toBeInTheDocument();
     expect(screen.getByText('Actions')).toBeInTheDocument();
   });
 
@@ -194,19 +192,16 @@ describe('ServiceRequestsPage.tsx', () => {
     renderServiceRequestsPage();
     const createButton = screen.getByRole('button', { name: /Create New Request/i });
     await user.click(createButton);
-    expect(mockNavigate).toHaveBeenCalledWith('/service-requests/new'); // Or the correct path
+    expect(mockNavigate).toHaveBeenCalledWith('/service-requests/new');
   });
 
   it('navigates to view service request details when view icon is clicked', async () => {
     const user = userEvent.setup();
     renderServiceRequestsPage();
-    // DataGrid actions are often buttons with aria-label or specific test ids might be needed if not directly named
-    // The action item in ServiceRequestsPage has label="View"
     const viewButtons = await screen.findAllByRole('button', { name: /View/i });
-    expect(viewButtons[0]).toBeInTheDocument(); // Assuming at least one row with a view button
+    expect(viewButtons[0]).toBeInTheDocument();
 
     await user.click(viewButtons[0]);
-    // The component navigates using request_id (e.g., "SR-001"), not the numeric id.
     expect(mockNavigate).toHaveBeenCalledWith(`/service-requests/view/${mockServiceRequests[0].request_id}`);
   });
 });

--- a/itsm_frontend/tsconfig.app.json
+++ b/itsm_frontend/tsconfig.app.json
@@ -3,7 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable", "ES2022"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
This batch of fixes addresses:
- Missing 'email' property in AuthUser mocks across multiple test files.
- Incorrect UIContextType mocks (confirmDialogConfig, isConfirmDialogVisible).
- TypeScript lib configuration for Object.hasOwn.
- Specific errors in coreApi.ts (no-explicit-any) and AssetList.test.tsx (vendor_name property).