### PR TITLE
Fix: Address third batch of frontend TypeScript/ESLint errors

### DIFF
--- a/itsm_frontend/src/api/authApi.ts
+++ b/itsm_frontend/src/api/authApi.ts
@@ -29,10 +29,11 @@ export const loginApi = async (
     name: string;
     role: string;
     id: number;
+    email: string; // Added email
     is_staff: boolean;
     groups: string[];
-    department_id?: number | null; // Added
-    department_name?: string | null; // Added
+    department_id?: number | null;
+    department_name?: string | null;
   };
 }> => {
   try {
@@ -52,18 +53,20 @@ export const loginApi = async (
     const token: string = data.access;
 
     // Now that we have a token, we can use our new apiClient for the authenticated call.
-    // Update the type of loggedInUser to include is_staff
+    // Update the type of loggedInUser to include is_staff and email
     const loggedInUser: {
   id: number;
   name: string;
+  email: string; // Added email
   role: string;
   is_staff: boolean;
   groups: string[];
-  department_id?: number | null; // Added
-  department_name?: string | null; // Added
+  department_id?: number | null;
+  department_name?: string | null;
 } = {
   id: 0,
   name: username,
+  email: '', // Initialize email
   role: 'user', // Default role, will be updated based on is_staff
   is_staff: false, // Default is_staff
   groups: [], // Initialize groups as an empty array
@@ -86,6 +89,7 @@ export const loginApi = async (
           currentUser.first_name && currentUser.last_name
             ? `${currentUser.first_name} ${currentUser.last_name}`
             : currentUser.username;
+        loggedInUser.email = currentUser.email; // Populate email
         loggedInUser.is_staff = currentUser.is_staff;
         loggedInUser.role = currentUser.is_staff ? 'admin' : 'user';
 

--- a/itsm_frontend/src/mocks/handlers/procurementHandlers.ts
+++ b/itsm_frontend/src/mocks/handlers/procurementHandlers.ts
@@ -68,6 +68,8 @@ export const procurementHandlers = [
         {
           id: 1, item_description: 'Approved IOM 1 (MSW)', quantity: 2, estimated_cost: 100,
           status: 'approved', reason: 'Urgent', requested_by: 1, requested_by_username: 'test', request_date: new Date().toISOString(),
+          created_at: new Date().toISOString(), // Added
+          updated_at: new Date().toISOString(), // Added
           // Add other required fields for PurchaseRequestMemo
           iom_id: 'IM-001', department: null, project: null, priority: 'medium',
         },
@@ -155,6 +157,8 @@ export const procurementHandlers = [
       attachments: data.has('attachments') ? `http://localhost/mock-attachment/${(data.get('attachments') as File).name}` : null,
       requested_by: 1, // Mock user ID
       requested_by_username: 'msw_user',
+      created_at: now, // Added
+      updated_at: now, // Added
       // approver fields typically null on creation
       approver: null,
       approver_username: null,
@@ -179,6 +183,8 @@ export const procurementHandlers = [
       request_date: now,
       requested_by: 1, // Mock user ID
       requested_by_username: 'msw_user',
+      created_at: now, // Added
+      updated_at: now, // Added
       currency: data.get('currency') as string || 'USD',
       invoice_date: data.get('invoice_date') as string || undefined, // Match CheckRequest type (optional string)
       invoice_number: data.get('invoice_number') as string || undefined, // Match CheckRequest type (optional string)

--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestDetailView.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestDetailView.test.tsx
@@ -96,8 +96,8 @@ const baseCheckRequestData: CheckRequest = {
   recurring_payment: null,
   recurring_payment_details: null,
   attachments: 'http://example.com/cr_attachment.pdf',
-  // Properties from CheckRequest type in procurementTypes.ts (created_at, updated_at were missing from problem.MD but are in the type)
-  // Assuming these are not strictly required for all tests or will be added if tests fail for their absence.
+  created_at: '2024-07-15T09:00:00Z', // Added based on type update
+  updated_at: '2024-07-20T10:00:00Z', // Added based on type update
 };
 
 

--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestForm.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestForm.test.tsx
@@ -138,6 +138,8 @@ describe('CheckRequestForm', () => {
       payment_date: null,
       transaction_id: null,
       payment_notes: null,
+      created_at: '2024-07-01T00:00:00Z', // Added
+      updated_at: '2024-07-01T00:00:00Z', // Added
     };
     vi.mocked(procurementApi.getCheckRequestById).mockResolvedValue(mockCheckRequest);
 
@@ -248,6 +250,8 @@ describe('CheckRequestForm', () => {
       payment_date: null,
       transaction_id: null,
       payment_notes: null,
+      created_at: now, // Added
+      updated_at: now, // Added
     };
 
     vi.mocked(procurementApi.createCheckRequest).mockResolvedValue(createdCRMock);

--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
@@ -40,10 +40,10 @@ const renderWithProviders = (ui: React.ReactElement) => {
 
 const mockCRs: CheckRequest[] = [
   {
-    id: 1, cr_id: 'CR-001', purchase_order: 1, purchase_order_number: 'PO-001', request_date: '2024-02-01T10:00:00Z', status: 'pending_approval', amount: "500", currency: 'USD', payee_name: 'Vendor X', requested_by_username: 'testuser', created_at: '2024-02-01T10:00:00Z', updated_at: '2024-02-01T10:00:00Z', reason_for_payment: 'Payment for PO-001', expense_category_name: 'Software', attachments: null, is_urgent: false,
+    id: 1, cr_id: 'CR-001', purchase_order: 1, purchase_order_number: 'PO-001', request_date: '2024-02-01T10:00:00Z', status: 'pending_approval', amount: "500", currency: 'USD', payee_name: 'Vendor X', requested_by: 1, requested_by_username: 'testuser', created_at: '2024-02-01T10:00:00Z', updated_at: '2024-02-01T10:00:00Z', reason_for_payment: 'Payment for PO-001', expense_category_name: 'Software', attachments: null, is_urgent: false,
   },
   {
-    id: 2, cr_id: 'CR-002', purchase_order: null, purchase_order_number: null, request_date: '2024-02-05T11:00:00Z', status: 'approved', amount: "150", currency: 'USD', payee_name: 'Consultant Y', requested_by_username: 'admin', created_at: '2024-02-05T11:00:00Z', updated_at: '2024-02-05T11:00:00Z', reason_for_payment: 'Consulting services', expense_category_name: 'Services', attachments: null, is_urgent: true,
+    id: 2, cr_id: 'CR-002', purchase_order: null, purchase_order_number: null, request_date: '2024-02-05T11:00:00Z', status: 'approved', amount: "150", currency: 'USD', payee_name: 'Consultant Y', requested_by: 2, requested_by_username: 'admin', created_at: '2024-02-05T11:00:00Z', updated_at: '2024-02-05T11:00:00Z', reason_for_payment: 'Consulting services', expense_category_name: 'Services', attachments: null, is_urgent: true,
   },
 ];
 

--- a/itsm_frontend/src/modules/procurement/components/purchase-orders/PurchaseOrderDetailView.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-orders/PurchaseOrderDetailView.test.tsx
@@ -93,7 +93,7 @@ const basePurchaseOrderData: PurchaseOrder = {
   revision_number: 0,
   attachments: 'http://example.com/po_attachment.pdf',
   internal_office_memo: 10, // IOM ID
-  related_contract_id: 20, // Contract ID
+  related_contract: 20, // Contract ID - Renamed from related_contract_id
   related_contract_details: 'Contract C20-Alpha',
 };
 

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoForm.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoForm.test.tsx
@@ -121,6 +121,8 @@ describe('PurchaseRequestMemoForm', () => {
       approver_username: null,
       decision_date: null,
       approver_comments: null,
+      created_at: '2024-07-01T00:00:00Z', // Added
+      updated_at: '2024-07-01T00:00:00Z', // Added
     };
     vi.mocked(procurementApi.getPurchaseRequestMemoById).mockResolvedValue(mockMemo);
     const mockDepartments: Department[] = [{ id: 1, name: 'Test Dept', department_code: 'TD001' }];
@@ -197,6 +199,8 @@ describe('PurchaseRequestMemoForm', () => {
         decision_date: null,
         approver_comments: null,
         attachments: null,
+        created_at: now, // Added
+        updated_at: now, // Added
     };
 
     const mockDepartments: Department[] = [{ id: 1, name: 'Engineering', department_code: 'ENG' }];

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
@@ -48,7 +48,7 @@ const mockPurchaseRequestTemplate: PaginatedResponse<IOMTemplate> = {
       // Add other fields from IOMTemplate as needed, with default/mock values
       created_by: 1,
       // updated_by: 1, // Removed as it's not in IOMTemplate type (updated_at is present)
-      form_layout: "{}",
+      // form_layout: "{}", // Removed as it's not in IOMTemplate type
       form_title: "Purchase Request Memo",
       is_active: true,
       related_module: "procurement",
@@ -74,12 +74,12 @@ const mockMemos: PurchaseRequestMemo[] = [
   {
     id: 1, iom_id: 'IOM-001', item_description: 'Laptop Pro', priority: 'high', department: 1, department_name: 'IT',
     requested_by: 1, requested_by_username: 'jdoe', request_date: '2024-01-15T10:00:00Z', status: 'pending', estimated_cost: 1500,
-    reason: 'Need new laptop', quantity: 1, project: null, project_name: null, required_delivery_date: null, suggested_vendor: null, suggested_vendor_name: null, attachments: null, approver: null, approver_username: null, decision_date: null, approver_comments: null,
+    reason: 'Need new laptop', quantity: 1, project: null, project_name: null, required_delivery_date: null, suggested_vendor: null, suggested_vendor_name: null, attachments: null, approver: null, approver_username: null, decision_date: null, approver_comments: null, created_at: '2024-01-15T10:00:00Z', updated_at: '2024-01-15T10:00:00Z',
   },
   {
     id: 2, iom_id: 'IOM-002', item_description: 'Office Chairs', priority: 'medium', department: 2, department_name: 'HR',
     requested_by: 2, requested_by_username: 'asmith', request_date: '2024-01-16T11:00:00Z', status: 'approved', estimated_cost: 300,
-    reason: 'New hires', quantity: 2, project: null, project_name: null, required_delivery_date: null, suggested_vendor: null, suggested_vendor_name: null, attachments: null, approver: 1, approver_username: 'admin', decision_date: '2024-01-17T10:00:00Z', approver_comments: 'Approved',
+    reason: 'New hires', quantity: 2, project: null, project_name: null, required_delivery_date: null, suggested_vendor: null, suggested_vendor_name: null, attachments: null, approver: 1, approver_username: 'admin', decision_date: '2024-01-17T10:00:00Z', approver_comments: 'Approved', created_at: '2024-01-16T11:00:00Z', updated_at: '2024-01-17T10:00:00Z',
   },
 ];
 

--- a/itsm_frontend/src/modules/service-requests/components/ServiceRequestForm.test.tsx
+++ b/itsm_frontend/src/modules/service-requests/components/ServiceRequestForm.test.tsx
@@ -25,7 +25,7 @@ vi.mock('../../../context/auth/useAuth');
 vi.mock('../../../context/UIContext/useUI');
 
 const mockNavigate = vi.fn();
-const mockUseParamsFn = vi.fn(() => ({ requestId: undefined })); // Persistent mock function
+const mockUseParamsFn = vi.fn<[], { requestId?: string }>(() => ({ requestId: undefined })); // Persistent mock function with explicit type
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -92,6 +92,11 @@ describe('ServiceRequestForm.tsx', () => {
       confirmDialogMessage: '',
       confirmDialogOnConfirm: vi.fn(),
       confirmDialogOnCancel: undefined,
+      // Added missing snackbar properties
+      snackbarOpen: false,
+      snackbarMessage: '',
+      snackbarSeverity: 'info',
+      hideSnackbar: vi.fn(),
     });
     vi.mocked(assetApi.getAssetCategories).mockResolvedValue(mockCategories);
     vi.mocked(serviceRequestApi.createServiceRequest).mockResolvedValue({ id: 123, request_id: 'SR-NEW-123' } as ServiceRequest);

--- a/itsm_frontend/src/modules/service-requests/pages/ServiceRequestsPage.test.tsx
+++ b/itsm_frontend/src/modules/service-requests/pages/ServiceRequestsPage.test.tsx
@@ -123,6 +123,11 @@ describe('ServiceRequestsPage.tsx', () => {
       confirmDialogMessage: '',
       confirmDialogOnConfirm: vi.fn(),
       confirmDialogOnCancel: undefined,
+      // Added missing snackbar properties
+      snackbarOpen: false,
+      snackbarMessage: '',
+      snackbarSeverity: 'info',
+      hideSnackbar: vi.fn(),
     });
 
     vi.mocked(serviceRequestApi.getServiceRequests).mockResolvedValue(mockPaginatedSRsResponse);


### PR DESCRIPTION
This commit includes a comprehensive set of fixes for errors identified in the latest linting/type-checking pass:

- AuthUser Mocks: Ensured all `useAuth().user` mocks and AuthUser instantiations consistently include the `email` property across numerous test files. Corrected `authApi.ts` to ensure `loginApi` properly returns `email` in the user object, resolving related errors in `AuthContext.tsx`.
- UIContextType Mocks: Thoroughly updated `useUI` mocks in all affected test files to include missing properties (`snackbarOpen`, `snackbarMessage`, `snackbarSeverity`, `hideSnackbar`) and use correct properties for dialogs, aligning with the `UIContextType` definition.
- Mock Handlers: Added missing `created_at` and `updated_at` timestamps to `PurchaseRequestMemo` and `CheckRequest` mocks in `mocks/handlers/procurementHandlers.ts`.
- Specific File Errors:
    - `AuthContext.test.tsx`: Changed `@ts-ignore` to `@ts-expect-error`.
    - `IomPreviewRenderer.tsx`: Modified a catch block to remove an unused error variable.
    - `CheckRequestList.test.tsx`: Added missing `requested_by` ID to mock data.
    - `CheckRequestDetailView.test.tsx`: Added missing timestamps to mock data.
    - `CheckRequestForm.test.tsx`: Added missing timestamps to mock data.
    - `PurchaseOrderDetailView.test.tsx`: Corrected mock data for `related_contract` and addressed potential nullability on `unit_price`.
    - `PurchaseRequestMemoForm.test.tsx`: Added missing timestamps to mock data.
    - `PurchaseRequestMemoList.test.tsx`: Removed invalid `form_layout` from `IOMTemplate` mock and added timestamps to `PurchaseRequestMemo` mocks.
    - `ServiceRequestForm.test.tsx`: Refined `useParams` mocking strategy.
- Type Definitions: Added `created_at` and `updated_at` to `CheckRequest` and `PurchaseRequestMemo` interfaces in `procurementTypes.ts`.