### PR TITLE
Fix various lint and type errors in test files

### DIFF
--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
@@ -638,7 +638,7 @@ describe('CheckRequestList', () => {
       it(`handles "Cancel Request" for "${crInstance.status}" CR: shows button, opens dialog, confirms, calls API`, async () => {
         vi.mocked(useAuthHook.useAuth)().user = { ...mockUserStaff, id: crInstance.requested_by }; // User is requester or staff
 
-        const mockShowConfirmDialog = vi.fn((title, message, onConfirm) => onConfirm()); // Auto-confirm
+        const mockShowConfirmDialog = vi.fn((_title, _message, onConfirm) => onConfirm()); // Auto-confirm
         vi.mocked(useUIHook.useUI)().showConfirmDialog = mockShowConfirmDialog;
 
         const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
@@ -670,7 +670,6 @@ describe('CheckRequestList', () => {
 
     it('Cancel dialog dismissal does not call API', async () => {
         vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
-        // @ts-expect-error Unused parameters _title, _message, _onConfirm are part of the signature but not used in this specific mock.
         const mockShowConfirmDialog = vi.fn((_title, _message, _onConfirm, onCancel) => { if(onCancel) onCancel(); });
         vi.mocked(useUIHook.useUI)().showConfirmDialog = mockShowConfirmDialog;
 

--- a/itsm_frontend/src/modules/procurement/components/purchase-orders/PurchaseOrderList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-orders/PurchaseOrderList.test.tsx
@@ -502,8 +502,8 @@ describe('PurchaseOrderList', () => {
       // Attempting to click disabled buttons should not result in navigation or snackbar
       // userEvent.click on a disabled button typically does nothing or might even error in some setups.
       // We are primarily verifying the disabled state.
-      await user.click(printPreviewButton).catch(_e => {}); // Suppress error if userEvent throws on disabled
-      await user.click(printSelectedButton).catch(_e => {}); // Suppress error if userEvent throws on disabled
+      await user.click(printPreviewButton).catch(() => {}); // Suppress error if userEvent throws on disabled
+      await user.click(printSelectedButton).catch(() => {}); // Suppress error if userEvent throws on disabled
 
       expect(showSnackbar).not.toHaveBeenCalledWith('Please select purchase orders to print.', 'warning');
       expect(mockNavigate).not.toHaveBeenCalled();


### PR DESCRIPTION
- Addressed no-explicit-any, unused-ts-expect-error, declared-but-not-read, and no-unused-vars errors in test files.
- Reverted some no-explicit-any fixes that caused new TS2322 build failures, restoring `as any` for those lines.

Note: The build may still fail due to pre-existing TS2345 errors (Argument of type 'undefined' is not assignable to parameter) that originate in component source code, which were not modified.