### PR TITLE
Further address lint/type errors in test files

### DIFF
--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
@@ -797,8 +797,8 @@ describe('CheckRequestList', () => {
       expect(printSelectedButton).toBeDisabled();
 
       mockNavigate.mockClear();
-      await user.click(printPreviewButton).catch(_e => {}); // Ignored error for disabled button click
-      await user.click(printSelectedButton).catch(_e => {}); // Ignored error for disabled button click
+      await user.click(printPreviewButton).catch(() => {}); // Ignored error for disabled button click
+      await user.click(printSelectedButton).catch(() => {}); // Ignored error for disabled button click
 
       expect(showSnackbar).not.toHaveBeenCalledWith('Please select check requests to print.', 'warning');
       expect(mockNavigate).not.toHaveBeenCalled();


### PR DESCRIPTION
- Fixed new no-unused-vars errors in CheckRequestList.test.tsx by using optional catch binding for error parameters.

Known remaining issues:
- ESLint warnings for no-explicit-any persist where stricter typing caused build failures (TS2322) and changes were reverted.
- Build continues to fail due to TS2345 errors (Argument of type 'undefined' is not assignable to parameter) originating in component source code, which were not modified.