### PR TITLE
Further ESLint and TypeScript error resolution in tests

### DIFF
--- a/itsm_frontend/src/api/authApi.ts
+++ b/itsm_frontend/src/api/authApi.ts
@@ -42,7 +42,7 @@ export const loginApi = async (
       try {
         const errorData = await tokenResponse.json();
         errorDetail = errorData.detail || errorDetail;
-      } catch (e) {
+      } catch { // Omitted error variable as it's not used
         // Ignore if response is not JSON
       }
       throw new Error(errorDetail);

--- a/itsm_frontend/src/context/auth/AuthContext.test.tsx
+++ b/itsm_frontend/src/context/auth/AuthContext.test.tsx
@@ -157,7 +157,7 @@ describe('AuthContext', () => {
       // Define a user object that is structurally an AuthUser but with an id that will fail runtime validation.
       // All other fields, including email, must conform to AuthUser.
       const userForApiInvalidId: AuthUser = {
-        id: undefined as any, // Makes !user.id true, or typeof user.id !== 'number' true. Cast to any for TS.
+        id: undefined as unknown as number, // Makes !user.id true, or typeof user.id !== 'number' true.
         name: 'User With Invalid ID',
         email: 'invalid-id@example.com', // Ensure email is a string.
         role: 'guest',

--- a/itsm_frontend/src/modules/genericIom/types/genericIomTypes.ts
+++ b/itsm_frontend/src/modules/genericIom/types/genericIomTypes.ts
@@ -17,7 +17,7 @@ export type GenericIomStatus =
   | 'cancelled';
 
 // Structure for the data_payload - can be any JSON object
-export type IomDataPayload = Record<string, any>; // Or Record<string, unknown> for stricter typing
+export type IomDataPayload = Record<string, unknown>; // Changed 'any' to 'unknown' for stricter typing
 
 // Interface for a GenericIOM object received from the API
 export interface GenericIOM {

--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestDetailView.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestDetailView.test.tsx
@@ -143,9 +143,8 @@ describe('CheckRequestDetailView', () => {
     vi.mocked(procurementApi.getCheckRequestById).mockRejectedValueOnce(notFoundError);
     renderComponent('1'); // Attempt to fetch CR with ID '1' that will be "not found"
     await waitFor(() => {
-      // The component should catch the error and display an appropriate message.
-      // This assertion might need to be adjusted if the component displays the error differently.
-      expect(screen.getByText(/Check Request not found./i)).toBeInTheDocument();
+      // Component displays the error message in an Alert
+      expect(screen.getByText(/Failed to fetch check request details: Check Request not found/i)).toBeInTheDocument();
     });
   });
 

--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestDetailView.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestDetailView.tsx
@@ -218,7 +218,7 @@ const CheckRequestDetailView: React.FC = () => {
           <Typography variant="h6" gutterBottom>
             Request Information {checkRequest.cr_id && `(${checkRequest.cr_id})`}
           </Typography>
-          <Typography>
+          <Typography component="div"> {/* Changed from p to div */}
             <strong>Status:</strong>{' '}
             <Chip
               label={checkRequest.status.replace(/_/g, ' ')}
@@ -233,7 +233,7 @@ const CheckRequestDetailView: React.FC = () => {
             <strong>Request Date:</strong>{' '}
             {formatDateString(checkRequest.request_date)}
           </Typography>
-           <Typography>
+           <Typography component="div"> {/* Changed from p to div */}
             <strong>Urgent:</strong> {checkRequest.is_urgent ? <Chip label="Yes" color="error" size="small" /> : 'No'}
           </Typography>
           <Typography>

--- a/itsm_frontend/src/modules/procurement/components/purchase-orders/PurchaseOrderDetailView.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-orders/PurchaseOrderDetailView.test.tsx
@@ -140,9 +140,8 @@ describe('PurchaseOrderDetailView', () => {
     vi.mocked(getPurchaseOrderById).mockRejectedValueOnce(notFoundError);
     renderComponent('1'); // Attempt to fetch PO with ID '1' that will be "not found"
     await waitFor(() => {
-      // The component should catch the error and display an appropriate message.
-      // This assertion might need to be adjusted if the component displays the error differently.
-      expect(screen.getByText(/Purchase Order not found./i)).toBeInTheDocument();
+      // Component displays the error message in an Alert
+      expect(screen.getByText(/Failed to fetch purchase order details: Purchase Order not found/i)).toBeInTheDocument();
     });
   });
 

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoDetailView.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoDetailView.test.tsx
@@ -130,9 +130,8 @@ describe('PurchaseRequestMemoDetailView', () => {
     vi.mocked(getPurchaseRequestMemoById).mockRejectedValueOnce(notFoundError);
     renderComponent('1'); // Attempt to fetch a memo that will "not be found"
     await waitFor(() => {
-      // The component should catch this error and display an appropriate message.
-      // This assertion might need to be adjusted based on actual component behavior.
-      expect(screen.getByText(/Internal Office Memo not found./i)).toBeInTheDocument();
+      // Component displays the error message in an Alert
+      expect(screen.getByText(/Failed to fetch memo details: Internal Office Memo not found/i)).toBeInTheDocument();
     });
   });
 

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoDetailView.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoDetailView.tsx
@@ -212,10 +212,10 @@ const PurchaseRequestMemoDetailView: React.FC = () => {
           <Typography variant="body1" sx={{ mb: 1 }}>
             <strong>Request Date:</strong> {formatDateString(memo.request_date)}
           </Typography>
-           <Typography component="div" variant="body1" sx={{ mb: 1 }}> {/* Changed to component="div" */}
+           <Typography component="div" variant="body1" sx={{ mb: 1 }}>
             <strong>Priority:</strong> <Chip label={memo.priority?.toUpperCase() || 'N/A'} size="small" />
           </Typography>
-          <Typography variant="body1" sx={{ mb: 2 }}>
+          <Typography component="div" variant="body1" sx={{ mb: 2 }}> {/* Changed to component="div" */}
             <strong>Status:</strong>&nbsp;
             <Chip
               label={memo.status

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.tsx
@@ -119,8 +119,15 @@ const PurchaseRequestMemoList: React.FC = () => {
         authenticatedFetch,
         params,
       );
-      setMemos(response.results);
-      setTotalMemos(response.count);
+      if (response && response.results) {
+        setMemos(response.results);
+        setTotalMemos(response.count);
+      } else {
+        console.error('Received invalid response from getPurchaseRequestMemos:', response);
+        setMemos([]);
+        setTotalMemos(0);
+        setError('Failed to retrieve valid memo data structure.');
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       setError(message || 'Failed to fetch purchase requests.');


### PR DESCRIPTION
This iteration of fixes addresses newly reported ESLint and TypeScript issues, and refines previous fixes:

- `itsm_frontend/src/context/auth/AuthContext.test.tsx`:
  - Resolved an ESLint `no-explicit-any` error on line 160 by changing `undefined as any` to `undefined as unknown as number` for the mock user's ID, enhancing type safety for test objects.

- `itsm_frontend/src/api/authApi.ts`:
  - Fixed an ESLint `no-unused-vars` error on line 45 by changing `catch (_e)` to `catch {}` (omitting the unused error variable), assuming the TypeScript/ECMAScript version supports optional catch binding.

- `itsm_frontend/src/modules/genericIom/types/genericIomTypes.ts`:
  - Resolved an ESLint `no-explicit-any` error on line 20 by changing `Record<string, any>` to the stricter `Record<string, unknown>` for `IomDataPayload` type.

- Detail View Components ('not found' tests):
  - For `CheckRequestDetailView.test.tsx` (line 141), `PurchaseOrderDetailView.test.tsx` (line 139), and `PurchaseRequestMemoDetailView.test.tsx` (line 130), the tests for 'not found' scenarios were updated. Based on TS2322 errors indicating that the respective `get...ById` API functions likely return `Promise<Entity>` (never null), the mocks were changed from resolving with `null` to `mockRejectedValueOnce(new Error('... not found'))`. This aligns tests with a stricter API contract where errors, not nulls, signify missing entities.

Post-run Analysis (from previous step):
- Linters (`eslint`, `tsc`) now pass without error.
- `AuthContext.test.tsx` tests now pass.
- The 'not found' tests for the three detail view components now fail due to assertions expecting simple error messages, while components render more verbose messages in Alert components. These assertions require updates.
- `CheckRequestDetailView.test.tsx` has persistent rendering/query failures, likely due to component HTML structure issues (div in p) noted in test output.
- `CheckRequestList.test.tsx` and `PurchaseRequestMemoList.test.tsx` tests passed. However, `PurchaseRequestMemoList.tsx` still logs a runtime TypeError from its source code, pointing to a component bug in handling API data.
- The original TS2345 errors in list components did not manifest as explicit TypeScript errors in the latest test run, suggesting they might be component-level logic issues not fully exercised by current test paths or were indirectly resolved.

Further component-level fixes and test assertion updates are needed for full test suite health.