### PR TITLE
Fix TypeScript errors and test failures in procurement components

### DIFF
--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.tsx
@@ -702,27 +702,27 @@ const CheckRequestList: React.FC = () => {
         </DialogContent>
         <DialogActions>
           <Button onClick={closeDialog}>Cancel</Button>
-          {dialogAction === 'reject' && (
+          {dialogAction === 'reject' && selectedRequest && (
             <Button
-              onClick={() => handleAccountsReject(selectedRequest!.id)}
+              onClick={() => handleAccountsReject(selectedRequest.id)}
               variant="contained"
               color="error"
             >
               Confirm Rejection
             </Button>
           )}
-          {dialogAction === 'approve' && (
+          {dialogAction === 'approve' && selectedRequest && (
             <Button
-              onClick={() => handleAccountsApprove(selectedRequest!.id)}
+              onClick={() => handleAccountsApprove(selectedRequest.id)}
               variant="contained"
               color="success"
             >
               Confirm Approval
             </Button>
           )}
-          {dialogAction === 'confirm_payment' && (
+          {dialogAction === 'confirm_payment' && selectedRequest && (
             <Button
-              onClick={() => handleConfirmPaymentSubmit(selectedRequest!.id)}
+              onClick={() => handleConfirmPaymentSubmit(selectedRequest.id)}
               variant="contained"
               color="primary"
             >

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
@@ -146,6 +146,8 @@ describe('PurchaseRequestMemoList', () => {
   });
 
   it('renders the main title and create button', async () => {
+    // Provide a default mock for getPurchaseRequestMemos for tests not focused on its data
+    vi.mocked(procurementApi.getPurchaseRequestMemos).mockResolvedValue(mockEmptyMemosResponse);
     renderWithProviders(<PurchaseRequestMemoList />);
     expect(screen.getByRole('heading', { name: /Internal Office Memo/i })).toBeInTheDocument();
     // Wait for template ID to be fetched before button becomes enabled
@@ -155,6 +157,7 @@ describe('PurchaseRequestMemoList', () => {
   });
 
   it('renders table headers correctly', async () => {
+    vi.mocked(procurementApi.getPurchaseRequestMemos).mockResolvedValue(mockEmptyMemosResponse);
     renderWithProviders(<PurchaseRequestMemoList />);
     await waitFor(() => { // Wait for data to load which triggers header rendering
       expect(screen.getByText('IOM ID')).toBeInTheDocument();
@@ -206,6 +209,7 @@ describe('PurchaseRequestMemoList', () => {
   });
 
   it('navigates to create new IOM form when "Create New Request" is clicked', async () => {
+    vi.mocked(procurementApi.getPurchaseRequestMemos).mockResolvedValue(mockEmptyMemosResponse);
     const user = userEvent.setup();
     renderWithProviders(<PurchaseRequestMemoList />);
     const createButton = await screen.findByRole('button', { name: /Create New Request/i });


### PR DESCRIPTION
- Corrected date formatting assertions in CheckRequestDetailView.test.tsx to align with component's internal date formatting (using toLocaleString for full ISO dates).
- Updated assertions for N/A values in CheckRequestDetailView.test.tsx to robustly check parentElement.textContent and corrected title assertion for null cr_id.
- Ensured PurchaseRequestMemoList.test.tsx provides default mocks for getPurchaseRequestMemos in tests not specifically focused on memo data, resolving 'invalid response' errors.
- Reverted explicit act() wrappers from various tests due to 'act not configured' messages from the test environment; userEvent and waitFor are managing async updates sufficiently for these tests to pass.
- All tests for CheckRequestDetailView, CheckRequestList, and PurchaseRequestMemoList are now passing.