### PR TITLE
Fix: Resolve TS errors and test failures in procurement module and fo…

### DIFF
--- a/itsm_frontend/src/utils/formatters.ts
+++ b/itsm_frontend/src/utils/formatters.ts
@@ -7,33 +7,48 @@ export const formatDate = (
 ): string => {
   if (!dateStr) return '';
   try {
-    const date = new Date(dateStr);
+    let date = new Date(dateStr); // Changed const to let
     // Check if date is valid
     if (isNaN(date.getTime())) {
       // Try to parse if it's already in YYYY-MM-DD format (e.g. from date picker)
       // and other parts of the system pass it as such.
       // This is a simple attempt, might need more robust parsing
-      const parts = dateStr.split('-');
+      const parts = dateStr.split(/[-/]/); // Handle both YYYY-MM-DD and YYYY/MM/DD
       if (parts.length === 3) {
         const year = parseInt(parts[0], 10);
         const month = parseInt(parts[1], 10) - 1; // Month is 0-indexed
         const day = parseInt(parts[2], 10);
-        const newDate = new Date(year, month, day);
-        if (!isNaN(newDate.getTime())) {
-          if (format === 'YYYY-MM-DD') {
-            return newDate.toISOString().split('T')[0];
-          }
-          return newDate.toLocaleDateString(); // Default locale format
+        // Ensure year is reasonable, e.g. 4 digits, to avoid misinterpreting parts
+        if (parts[0].length === 4 && !isNaN(year) && !isNaN(month) && !isNaN(day)) {
+            const newDate = new Date(year, month, day); // Creates local date
+            if (!isNaN(newDate.getTime())) {
+              // If successfully parsed, use this newDate object for formatting
+              date = newDate;
+            } else {
+                 return 'Invalid date'; // Invalid date from parts
+            }
+        } else {
+            return 'Invalid date'; // Parts not in expected YYYY-MM-DD or YYYY/MM/DD
         }
+      } else {
+        return 'Invalid date'; // Return if parsing fails or not enough parts
       }
-      return 'Invalid date'; // Return if parsing fails
     }
 
     if (format === 'YYYY-MM-DD') {
-      return date.toISOString().split('T')[0];
+      // Use local date parts to avoid timezone shift from toISOString()
+      const year = date.getFullYear();
+      const month = (date.getMonth() + 1).toString().padStart(2, '0');
+      const day = date.getDate().toString().padStart(2, '0');
+      return `${year}-${month}-${day}`;
     }
     // Add more formats if needed
-    return date.toLocaleDateString(); // Default to locale date string
+    // For full ISO strings like '2023-01-15T10:20:30Z', toLocaleString() is often desired
+    // For date-only strings like '2023-01-15', toLocaleDateString() is better.
+    // The initial `new Date(dateStr)` might already be local if dateStr has no time/TZ.
+    // If dateStr has Z or offset, it's UTC/specific offset.
+    // Defaulting to toLocaleDateString for general case if not YYYY-MM-DD
+    return date.toLocaleDateString();
   } catch {
     // console.error("Error formatting date:", dateStr, e);
     return 'Invalid date';


### PR DESCRIPTION
…rmatters

This commit addresses a series of TypeScript errors and resulting test failures primarily within the frontend procurement module components and a related utility function.

Key changes include:

1.  **Procurement Component Test Fixes (`CheckRequestDetailView.test.tsx`, `CheckRequestList.test.tsx`, `PurchaseRequestMemoList.test.tsx`):
    *   Corrected type inconsistencies in `AuthContext.test.tsx` for `AuthUser`.
    *   Addressed errors related to `null` or `undefined` arguments being passed to functions expecting concrete types in detail view and list components for Check Requests and Purchase Request Memos. This involved ensuring API mocks provide valid data structures (even if empty) and that components handle potentially undefined selections gracefully.
    *   Refined date formatting assertions in `CheckRequestDetailView.test.tsx` to use `toLocaleString()` or `toLocaleDateString()` directly, aligning with the component's internal `formatDateString` helper logic, which resolved "Invalid Date" errors.
    *   Improved assertions for "N/A" values in `CheckRequestDetailView.test.tsx` by checking `parentElement.textContent` for robustness and corrected title assertions for cases where `cr_id` is null.
    *   Ensured `PurchaseRequestMemoList.test.tsx` provides default mocks for `getPurchaseRequestMemos` in tests not specifically focused on memo data, resolving 'invalid response' console errors.
    *   Reverted explicit `act(...)` wrappers that were added, as test environment messages indicated `act` was not properly configured. Existing `waitFor` and `userEvent` (which has internal `act` wrapping) proved sufficient for tests to pass.

2.  **Date Formatter Fix (`src/utils/formatters.ts` and `formatters.test.ts`):
    *   Modified the `formatDate` utility to prevent timezone-related shifts when outputting in 'YYYY-MM-DD' format. This was achieved by using `getFullYear()`, `getMonth()`, and `getDate()` for constructing the formatted string, rather than relying on `toISOString()` which could shift dates based on the environment's timezone.
    *   Changed `const date` to `let date` within `formatDate` to allow reassignment after fallback parsing logic, fixing an ESBuild warning.
    *   Ensured all tests in `formatters.test.ts` pass after these changes, including those that previously failed due to timezone inconsistencies.

All targeted tests for the procurement module components and the `formatters.ts` utility are now passing. Pre-existing unrelated test failures in other modules remain.