### PR TITLE
Fix: Resolve TS errors, test failures, MUI imports, and genericIOM types

### DIFF
--- a/itsm_frontend/src/modules/genericIom/components/GenericIomDetailComponent.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/GenericIomDetailComponent.tsx
@@ -375,7 +375,7 @@ const GenericIomDetailComponent: React.FC<GenericIomDetailComponentProps> = ({ i
             <Grid item xs={12} md={fieldDef.type === 'text_area' ? 12 : 6} key={fieldDef.name}>
               <Box>
                 <Typography variant="subtitle2" color="textSecondary">{fieldDef.label}:</Typography>
-                <DisplayDynamicFieldValue field={fieldDef} value={iom.data_payload[fieldDef.name]} />
+                <DisplayDynamicFieldValue field={fieldDef} value={iom.data_payload[fieldDef.name] as FormFieldValue} />
               </Box>
             </Grid>
           ))}

--- a/itsm_frontend/src/modules/genericIom/components/GenericIomForm.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/GenericIomForm.tsx
@@ -291,7 +291,7 @@ const GenericIomForm: React.FC<GenericIomFormProps> = ({ parentRecordContext = n
                     <Grid item xs={12} md={fieldDef.type === 'text_area' ? 12 : (fieldDef.type === 'boolean' ? 12 : 6)} key={fieldDef.name}>
                         <DynamicIomFormFieldRenderer
                         field={fieldDef}
-                        value={dynamicFormData[fieldDef.name]}
+                        value={dynamicFormData[fieldDef.name] as FormFieldValue}
                         onChange={handleDynamicFieldChange}
                         disabled={isSubmitting}
                         />

--- a/itsm_frontend/src/modules/genericIom/components/IomPreviewRenderer.tsx
+++ b/itsm_frontend/src/modules/genericIom/components/IomPreviewRenderer.tsx
@@ -114,7 +114,7 @@ const IomPreviewRenderer: React.FC<IomPreviewRendererProps> = ({
                     <Typography variant="caption" color="text.secondary" display="block" sx={{ fontWeight: 'medium', fontSize: '0.75rem' }}>
                         {fieldDef.label}:
                     </Typography>
-                    <PreviewDisplayDynamicFieldValue field={fieldDef} value={dataPayload[fieldDef.name]} />
+                    <PreviewDisplayDynamicFieldValue field={fieldDef} value={dataPayload[fieldDef.name] as FormFieldValue} />
                     </Box>
                 </Grid>
                 ))}

--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
@@ -321,9 +321,11 @@ describe('CheckRequestList', () => {
     // --- Submit for Approval Button ---
     it('shows "Submit for Approval" button for "pending_submission" CR if user is requester, and calls API', async () => {
       vi.mocked(useAuthHook.useAuth)().user = { ...mockUserStaff, id: pendingSubmissionCR.requested_by };
+      const results1: CheckRequest[] = [pendingSubmissionCR];
+      const results2: CheckRequest[] = [{ ...pendingSubmissionCR, status: 'pending_approval' }];
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-        .mockResolvedValueOnce({ count: 1, results: [pendingSubmissionCR] } as PaginatedResponse<CheckRequest>)
-        .mockResolvedValueOnce({ count: 1, results: [{ ...pendingSubmissionCR, status: 'pending_approval' }] } as PaginatedResponse<CheckRequest>);
+        .mockResolvedValueOnce({ count: 1, results: results1 } as PaginatedResponse<CheckRequest>)
+        .mockResolvedValueOnce({ count: 1, results: results2 } as PaginatedResponse<CheckRequest>);
       const submitMock = vi.mocked(procurementApi.submitCheckRequestForApproval).mockResolvedValue(undefined);
       const user = userEvent.setup();
       renderWithProviders(<CheckRequestList />);
@@ -366,9 +368,11 @@ describe('CheckRequestList', () => {
     // --- Approve/Reject by Accounts ---
     it('handles "Approve" by accounts: shows button, opens dialog, confirms, calls API', async () => {
       vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
+      const results1: CheckRequest[] = [pendingApprovalCR];
+      const results2: CheckRequest[] = [{ ...pendingApprovalCR, status: 'approved' }];
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-        .mockResolvedValueOnce({ count: 1, results: [pendingApprovalCR] } as PaginatedResponse<CheckRequest>)
-        .mockResolvedValueOnce({ count: 1, results: [{ ...pendingApprovalCR, status: 'approved' }] } as PaginatedResponse<CheckRequest>);
+        .mockResolvedValueOnce({ count: 1, results: results1 } as PaginatedResponse<CheckRequest>)
+        .mockResolvedValueOnce({ count: 1, results: results2 } as PaginatedResponse<CheckRequest>);
       const approveMock = vi.mocked(procurementApi.approveCheckRequestByAccounts).mockResolvedValue(undefined);
       const user = userEvent.setup();
       renderWithProviders(<CheckRequestList />);
@@ -394,9 +398,11 @@ describe('CheckRequestList', () => {
 
     it('handles "Reject" by accounts: shows button, opens dialog, confirms, calls API', async () => {
       vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
+      const results1: CheckRequest[] = [pendingApprovalCR];
+      const results2: CheckRequest[] = [{ ...pendingApprovalCR, status: 'rejected' }];
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-        .mockResolvedValueOnce({ count: 1, results: [pendingApprovalCR] } as PaginatedResponse<CheckRequest>)
-        .mockResolvedValueOnce({ count: 1, results: [{ ...pendingApprovalCR, status: 'rejected' }] } as PaginatedResponse<CheckRequest>);
+        .mockResolvedValueOnce({ count: 1, results: results1 } as PaginatedResponse<CheckRequest>)
+        .mockResolvedValueOnce({ count: 1, results: results2 } as PaginatedResponse<CheckRequest>);
       const rejectMock = vi.mocked(procurementApi.rejectCheckRequestByAccounts).mockResolvedValue(undefined);
       const user = userEvent.setup();
       renderWithProviders(<CheckRequestList />);
@@ -440,9 +446,11 @@ describe('CheckRequestList', () => {
     it('handles "Mark Payment Processing": shows button for approved CR if staff, calls API', async () => {
       const approvedCR: CheckRequest = { ...mockCRs[0], id: 205, cr_id: 'CR-APPROVED', status: 'approved' };
       vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
+      const results1: CheckRequest[] = [approvedCR];
+      const results2: CheckRequest[] = [{ ...approvedCR, status: 'payment_processing' }];
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-        .mockResolvedValueOnce({ count: 1, results: [approvedCR] } as PaginatedResponse<CheckRequest>)
-        .mockResolvedValueOnce({ count: 1, results: [{ ...approvedCR, status: 'payment_processing' }] } as PaginatedResponse<CheckRequest>);
+        .mockResolvedValueOnce({ count: 1, results: results1 } as PaginatedResponse<CheckRequest>)
+        .mockResolvedValueOnce({ count: 1, results: results2 } as PaginatedResponse<CheckRequest>);
       const markProcessingMock = vi.mocked(procurementApi.markCheckRequestPaymentProcessing).mockResolvedValue(undefined);
       const user = userEvent.setup();
       renderWithProviders(<CheckRequestList />);
@@ -482,9 +490,11 @@ describe('CheckRequestList', () => {
     it(`handles "Confirm Payment" for "approved" CR: shows button, opens dialog, fills details, confirms, calls API`, async () => {
       const crInstance = approvedCRForPayment;
       vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
+      const results1: CheckRequest[] = [crInstance];
+      const results2: CheckRequest[] = [{ ...crInstance, status: 'paid' }];
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-          .mockResolvedValueOnce({ count: 1, results: [crInstance] } as PaginatedResponse<CheckRequest>)
-          .mockResolvedValueOnce({ count: 1, results: [{ ...crInstance, status: 'paid' }] } as PaginatedResponse<CheckRequest>);
+          .mockResolvedValueOnce({ count: 1, results: results1 } as PaginatedResponse<CheckRequest>)
+          .mockResolvedValueOnce({ count: 1, results: results2 } as PaginatedResponse<CheckRequest>);
         const confirmPaymentMock = vi.mocked(procurementApi.confirmCheckRequestPayment).mockResolvedValue(undefined);
 
         const user = userEvent.setup();
@@ -552,9 +562,11 @@ describe('CheckRequestList', () => {
     it(`handles "Confirm Payment" for "payment_processing" CR: shows button, opens dialog, fills details, confirms, calls API`, async () => {
       const crInstance = processingCRForPayment;
       vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
+      const results1: CheckRequest[] = [crInstance];
+      const results2: CheckRequest[] = [{ ...crInstance, status: 'paid' }];
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-          .mockResolvedValueOnce({ count: 1, results: [crInstance] } as PaginatedResponse<CheckRequest>)
-          .mockResolvedValueOnce({ count: 1, results: [{ ...crInstance, status: 'paid' }] } as PaginatedResponse<CheckRequest>);
+          .mockResolvedValueOnce({ count: 1, results: results1 } as PaginatedResponse<CheckRequest>)
+          .mockResolvedValueOnce({ count: 1, results: results2 } as PaginatedResponse<CheckRequest>);
       const confirmPaymentMock = vi.mocked(procurementApi.confirmCheckRequestPayment).mockResolvedValue(undefined);
 
       const user = userEvent.setup();
@@ -649,9 +661,11 @@ describe('CheckRequestList', () => {
         const mockShowConfirmDialog = vi.fn((_title, _message, onConfirm) => onConfirm()); // Auto-confirm
         vi.mocked(useUIHook.useUI)().showConfirmDialog = mockShowConfirmDialog;
 
+        const results1: CheckRequest[] = [crInstance];
+        const results2: CheckRequest[] = [{ ...crInstance, status: 'cancelled' }];
         const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-          .mockResolvedValueOnce({ count: 1, results: [crInstance] } as PaginatedResponse<CheckRequest>)
-          .mockResolvedValueOnce({ count: 1, results: [{ ...crInstance, status: 'cancelled' }] } as PaginatedResponse<CheckRequest>);
+          .mockResolvedValueOnce({ count: 1, results: results1 } as PaginatedResponse<CheckRequest>)
+          .mockResolvedValueOnce({ count: 1, results: results2 } as PaginatedResponse<CheckRequest>);
         const cancelMock = vi.mocked(procurementApi.cancelCheckRequest).mockResolvedValue(undefined);
 
         const user = userEvent.setup();

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
@@ -517,9 +517,11 @@ describe('PurchaseRequestMemoList', () => {
         snackbarSeverity: 'info',
         hideSnackbar: vi.fn(),
       });
+      const results1: PurchaseRequestMemo[] = [pendingMemoIsRequester];
+      const results2: PurchaseRequestMemo[] = [{...pendingMemoIsRequester, status: 'cancelled'}];
       const getMemosMock = vi.mocked(procurementApi.getPurchaseRequestMemos)
-        .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: [pendingMemoIsRequester] }) // Initial load
-        .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: [{...pendingMemoIsRequester, status: 'cancelled'}] }); // After cancellation
+        .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: results1 })
+        .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: results2 });
       const cancelMemoMock = vi.mocked(procurementApi.cancelPurchaseRequestMemo).mockResolvedValue(undefined); // API call for cancel
 
       const user = userEvent.setup();
@@ -557,9 +559,11 @@ describe('PurchaseRequestMemoList', () => {
         snackbarSeverity: 'info',
         hideSnackbar: vi.fn(),
         });
+        const results1: PurchaseRequestMemo[] = [pendingMemoNotRequester];
+        const results2: PurchaseRequestMemo[] = [{...pendingMemoNotRequester, status: 'cancelled'}];
         const getMemosMock = vi.mocked(procurementApi.getPurchaseRequestMemos)
-            .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: [pendingMemoNotRequester] }) // Initial load
-            .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: [{...pendingMemoNotRequester, status: 'cancelled'}] });
+            .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: results1 })
+            .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: results2 });
         const cancelMemoMock = vi.mocked(procurementApi.cancelPurchaseRequestMemo).mockResolvedValue(undefined);
 
         const user = userEvent.setup();
@@ -640,9 +644,11 @@ describe('PurchaseRequestMemoList', () => {
         user: mockUserStaff,
       });
 
+      const results1: PurchaseRequestMemo[] = [pendingMemoNotRequester];
+      const results2: PurchaseRequestMemo[] = [{...pendingMemoNotRequester, status: 'approved'}];
       const getMemosMock = vi.mocked(procurementApi.getPurchaseRequestMemos)
-        .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: [pendingMemoNotRequester] }) // Initial load
-        .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: [{...pendingMemoNotRequester, status: 'approved'}] }); // After approval
+        .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: results1 })
+        .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: results2 });
       const decideMemoMock = vi.mocked(procurementApi.decidePurchaseRequestMemo).mockResolvedValue(undefined);
 
       const user = userEvent.setup();
@@ -675,9 +681,11 @@ describe('PurchaseRequestMemoList', () => {
             user: mockUserStaff,
         });
 
+        const results1: PurchaseRequestMemo[] = [pendingMemoIsRequester];
+        const results2: PurchaseRequestMemo[] = [{...pendingMemoIsRequester, status: 'rejected'}];
         const getMemosMock = vi.mocked(procurementApi.getPurchaseRequestMemos)
-            .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: [pendingMemoIsRequester] }) // Initial load
-            .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: [{...pendingMemoIsRequester, status: 'rejected'}] }); // After rejection
+            .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: results1 })
+            .mockResolvedValueOnce({ count: 1, next: null, previous: null, results: results2 });
         const decideMemoMock = vi.mocked(procurementApi.decidePurchaseRequestMemo).mockResolvedValue(undefined);
 
         const user = userEvent.setup();


### PR DESCRIPTION
This commit addresses a series of TypeScript errors, resulting test failures, a runtime error concerning MUI's `useTheme` hook, and type issues in the generic IOM module.

Key changes include:

1.  **MUI `useTheme` Import Standardization:**
    *   Corrected `useTheme` imports in `LoginPage.tsx`, `HomePage.tsx`, and various PrintView components to consistently use `import { useTheme } from '@mui/material/styles';`. This resolved a runtime error related to Vite's pre-bundling of MUI modules.

2.  **Procurement Component Test Fixes (`CheckRequestDetailView.test.tsx`, `CheckRequestList.test.tsx`, `PurchaseRequestMemoList.test.tsx`, `AuthContext.test.tsx`):
    *   Corrected type inconsistencies for `AuthUser` in `AuthContext.test.tsx`.
    *   Addressed errors related to `null` or `undefined` arguments being passed to functions expecting concrete types. This involved ensuring API mocks provide valid data structures and that components handle potentially undefined selections gracefully.
    *   Refined date formatting assertions in `CheckRequestDetailView.test.tsx`.
    *   Updated assertions for "N/A" values and titles in `CheckRequestDetailView.test.tsx`.
    *   Ensured `PurchaseRequestMemoList.test.tsx` and `CheckRequestList.test.tsx` provide explicitly typed `results` arrays in mock API responses to satisfy static type checking for TS2345 errors.

3.  **Date Formatter Fix (`src/utils/formatters.ts` and `formatters.test.ts`):
    *   Modified the `formatDate` utility to prevent timezone-related shifts for 'YYYY-MM-DD' output.
    *   Corrected `const date` to `let date` within `formatDate`.
    *   Adjusted assertions in `formatters.test.ts` to align with the corrected behavior of `formatDate`.

4.  **Generic IOM Component Type Fixes (`GenericIomDetailComponent.tsx`, `GenericIomForm.tsx`, `IomPreviewRenderer.tsx`):
    *   Addressed TS2322 errors (`Type 'unknown' is not assignable to type 'FormFieldValue'`) by applying type assertions (`as FormFieldValue`) when passing values from `IomDataPayload` (where values are `unknown`) to components expecting `FormFieldValue`.

All targeted tests for the procurement module components, generic IOM components, `formatters.ts`, `LoginPage.tsx`, and `HomePage.tsx` are now passing. Pre-existing unrelated test failures in other modules remain.