### PR TITLE
Fix: Comprehensive TypeScript error resolution and test corrections

### DIFF
--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
@@ -322,16 +322,19 @@ describe('CheckRequestList', () => {
     it('shows "Submit for Approval" button for "pending_submission" CR if user is requester, and calls API', async () => {
       vi.mocked(useAuthHook.useAuth)().user = { ...mockUserStaff, id: pendingSubmissionCR.requested_by };
 
-      const mockResponse1: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [pendingSubmissionCR]
-      };
-      const mockResponse2: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [{ ...pendingSubmissionCR, status: 'pending_approval' }]
-      };
-
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-        .mockResolvedValueOnce(mockResponse1)
-        .mockResolvedValueOnce(mockResponse2);
+        .mockResolvedValueOnce({
+          count: 1,
+          next: null,
+          previous: null,
+          results: [pendingSubmissionCR as CheckRequest] // Ensure element is CheckRequest
+        } as PaginatedResponse<CheckRequest>)
+        .mockResolvedValueOnce({
+          count: 1,
+          next: null,
+          previous: null,
+          results: [{ ...pendingSubmissionCR, status: 'pending_approval' } as CheckRequest] // Ensure element is CheckRequest
+        } as PaginatedResponse<CheckRequest>);
       const submitMock = vi.mocked(procurementApi.submitCheckRequestForApproval).mockResolvedValue(undefined);
       const user = userEvent.setup();
       renderWithProviders(<CheckRequestList />);
@@ -374,15 +377,13 @@ describe('CheckRequestList', () => {
     // --- Approve/Reject by Accounts ---
     it('handles "Approve" by accounts: shows button, opens dialog, confirms, calls API', async () => {
       vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
-      const mockResponse1: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [pendingApprovalCR]
-      };
-      const mockResponse2: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [{ ...pendingApprovalCR, status: 'approved' }]
-      };
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-        .mockResolvedValueOnce(mockResponse1)
-        .mockResolvedValueOnce(mockResponse2);
+        .mockResolvedValueOnce({
+          count: 1, next: null, previous: null, results: [pendingApprovalCR as CheckRequest]
+        } as PaginatedResponse<CheckRequest>)
+        .mockResolvedValueOnce({
+          count: 1, next: null, previous: null, results: [{ ...pendingApprovalCR, status: 'approved' } as CheckRequest]
+        } as PaginatedResponse<CheckRequest>);
       const approveMock = vi.mocked(procurementApi.approveCheckRequestByAccounts).mockResolvedValue(undefined);
       const user = userEvent.setup();
       renderWithProviders(<CheckRequestList />);
@@ -408,15 +409,13 @@ describe('CheckRequestList', () => {
 
     it('handles "Reject" by accounts: shows button, opens dialog, confirms, calls API', async () => {
       vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
-      const mockResponse1: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [pendingApprovalCR]
-      };
-      const mockResponse2: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [{ ...pendingApprovalCR, status: 'rejected' }]
-      };
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-        .mockResolvedValueOnce(mockResponse1)
-        .mockResolvedValueOnce(mockResponse2);
+        .mockResolvedValueOnce({
+          count: 1, next: null, previous: null, results: [pendingApprovalCR as CheckRequest]
+        } as PaginatedResponse<CheckRequest>)
+        .mockResolvedValueOnce({
+          count: 1, next: null, previous: null, results: [{ ...pendingApprovalCR, status: 'rejected' } as CheckRequest]
+        } as PaginatedResponse<CheckRequest>);
       const rejectMock = vi.mocked(procurementApi.rejectCheckRequestByAccounts).mockResolvedValue(undefined);
       const user = userEvent.setup();
       renderWithProviders(<CheckRequestList />);
@@ -460,15 +459,13 @@ describe('CheckRequestList', () => {
     it('handles "Mark Payment Processing": shows button for approved CR if staff, calls API', async () => {
       const approvedCR: CheckRequest = { ...mockCRs[0], id: 205, cr_id: 'CR-APPROVED', status: 'approved' };
       vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
-      const mockResponse1: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [approvedCR]
-      };
-      const mockResponse2: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [{ ...approvedCR, status: 'payment_processing' }]
-      };
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-        .mockResolvedValueOnce(mockResponse1)
-        .mockResolvedValueOnce(mockResponse2);
+        .mockResolvedValueOnce({
+          count: 1, next: null, previous: null, results: [approvedCR as CheckRequest]
+        } as PaginatedResponse<CheckRequest>)
+        .mockResolvedValueOnce({
+          count: 1, next: null, previous: null, results: [{ ...approvedCR, status: 'payment_processing' } as CheckRequest]
+        } as PaginatedResponse<CheckRequest>);
       const markProcessingMock = vi.mocked(procurementApi.markCheckRequestPaymentProcessing).mockResolvedValue(undefined);
       const user = userEvent.setup();
       renderWithProviders(<CheckRequestList />);
@@ -508,15 +505,13 @@ describe('CheckRequestList', () => {
     it(`handles "Confirm Payment" for "approved" CR: shows button, opens dialog, fills details, confirms, calls API`, async () => {
       const crInstance = approvedCRForPayment;
       vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
-      const mockResponse1: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [crInstance]
-      };
-      const mockResponse2: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [{ ...crInstance, status: 'paid' }]
-      };
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-          .mockResolvedValueOnce(mockResponse1)
-          .mockResolvedValueOnce(mockResponse2);
+          .mockResolvedValueOnce({
+            count: 1, next: null, previous: null, results: [crInstance as CheckRequest]
+          } as PaginatedResponse<CheckRequest>)
+          .mockResolvedValueOnce({
+            count: 1, next: null, previous: null, results: [{ ...crInstance, status: 'paid' } as CheckRequest]
+          } as PaginatedResponse<CheckRequest>);
         const confirmPaymentMock = vi.mocked(procurementApi.confirmCheckRequestPayment).mockResolvedValue(undefined);
 
         const user = userEvent.setup();
@@ -584,15 +579,13 @@ describe('CheckRequestList', () => {
     it(`handles "Confirm Payment" for "payment_processing" CR: shows button, opens dialog, fills details, confirms, calls API`, async () => {
       const crInstance = processingCRForPayment;
       vi.mocked(useAuthHook.useAuth)().user = mockUserStaff;
-      const mockResponse1: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [crInstance]
-      };
-      const mockResponse2: PaginatedResponse<CheckRequest> = {
-        count: 1, next: null, previous: null, results: [{ ...crInstance, status: 'paid' }]
-      };
       const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-          .mockResolvedValueOnce(mockResponse1)
-          .mockResolvedValueOnce(mockResponse2);
+          .mockResolvedValueOnce({
+            count: 1, next: null, previous: null, results: [crInstance as CheckRequest]
+          } as PaginatedResponse<CheckRequest>)
+          .mockResolvedValueOnce({
+            count: 1, next: null, previous: null, results: [{ ...crInstance, status: 'paid' } as CheckRequest]
+          } as PaginatedResponse<CheckRequest>);
       const confirmPaymentMock = vi.mocked(procurementApi.confirmCheckRequestPayment).mockResolvedValue(undefined);
 
       const user = userEvent.setup();
@@ -687,15 +680,13 @@ describe('CheckRequestList', () => {
         const mockShowConfirmDialog = vi.fn((_title, _message, onConfirm) => onConfirm()); // Auto-confirm
         vi.mocked(useUIHook.useUI)().showConfirmDialog = mockShowConfirmDialog;
 
-        const mockResponse1: PaginatedResponse<CheckRequest> = {
-          count: 1, next: null, previous: null, results: [crInstance]
-        };
-        const mockResponse2: PaginatedResponse<CheckRequest> = {
-          count: 1, next: null, previous: null, results: [{ ...crInstance, status: 'cancelled' }]
-        };
         const getRequestsMock = vi.mocked(procurementApi.getCheckRequests)
-          .mockResolvedValueOnce(mockResponse1)
-          .mockResolvedValueOnce(mockResponse2);
+          .mockResolvedValueOnce({
+            count: 1, next: null, previous: null, results: [crInstance as CheckRequest]
+          } as PaginatedResponse<CheckRequest>)
+          .mockResolvedValueOnce({
+            count: 1, next: null, previous: null, results: [{ ...crInstance, status: 'cancelled' } as CheckRequest]
+          } as PaginatedResponse<CheckRequest>);
         const cancelMock = vi.mocked(procurementApi.cancelCheckRequest).mockResolvedValue(undefined);
 
         const user = userEvent.setup();

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
@@ -517,15 +517,13 @@ describe('PurchaseRequestMemoList', () => {
         snackbarSeverity: 'info',
         hideSnackbar: vi.fn(),
       });
-      const mockResponse1: PaginatedResponse<PurchaseRequestMemo> = {
-        count: 1, next: null, previous: null, results: [pendingMemoIsRequester]
-      };
-      const mockResponse2: PaginatedResponse<PurchaseRequestMemo> = {
-        count: 1, next: null, previous: null, results: [{...pendingMemoIsRequester, status: 'cancelled'}]
-      };
       const getMemosMock = vi.mocked(procurementApi.getPurchaseRequestMemos)
-        .mockResolvedValueOnce(mockResponse1)
-        .mockResolvedValueOnce(mockResponse2);
+        .mockResolvedValueOnce({
+          count: 1, next: null, previous: null, results: [pendingMemoIsRequester as PurchaseRequestMemo]
+        } as PaginatedResponse<PurchaseRequestMemo>)
+        .mockResolvedValueOnce({
+          count: 1, next: null, previous: null, results: [{...pendingMemoIsRequester, status: 'cancelled'} as PurchaseRequestMemo]
+        } as PaginatedResponse<PurchaseRequestMemo>);
       const cancelMemoMock = vi.mocked(procurementApi.cancelPurchaseRequestMemo).mockResolvedValue(undefined); // API call for cancel
 
       const user = userEvent.setup();
@@ -563,15 +561,13 @@ describe('PurchaseRequestMemoList', () => {
         snackbarSeverity: 'info',
         hideSnackbar: vi.fn(),
         });
-        const mockResponse1: PaginatedResponse<PurchaseRequestMemo> = {
-          count: 1, next: null, previous: null, results: [pendingMemoNotRequester]
-        };
-        const mockResponse2: PaginatedResponse<PurchaseRequestMemo> = {
-          count: 1, next: null, previous: null, results: [{...pendingMemoNotRequester, status: 'cancelled'}]
-        };
         const getMemosMock = vi.mocked(procurementApi.getPurchaseRequestMemos)
-            .mockResolvedValueOnce(mockResponse1)
-            .mockResolvedValueOnce(mockResponse2);
+            .mockResolvedValueOnce({
+              count: 1, next: null, previous: null, results: [pendingMemoNotRequester as PurchaseRequestMemo]
+            } as PaginatedResponse<PurchaseRequestMemo>)
+            .mockResolvedValueOnce({
+              count: 1, next: null, previous: null, results: [{...pendingMemoNotRequester, status: 'cancelled'} as PurchaseRequestMemo]
+            } as PaginatedResponse<PurchaseRequestMemo>);
         const cancelMemoMock = vi.mocked(procurementApi.cancelPurchaseRequestMemo).mockResolvedValue(undefined);
 
         const user = userEvent.setup();
@@ -652,15 +648,13 @@ describe('PurchaseRequestMemoList', () => {
         user: mockUserStaff,
       });
 
-      const mockResponse1: PaginatedResponse<PurchaseRequestMemo> = {
-        count: 1, next: null, previous: null, results: [pendingMemoNotRequester]
-      };
-      const mockResponse2: PaginatedResponse<PurchaseRequestMemo> = {
-        count: 1, next: null, previous: null, results: [{...pendingMemoNotRequester, status: 'approved'}]
-      };
       const getMemosMock = vi.mocked(procurementApi.getPurchaseRequestMemos)
-        .mockResolvedValueOnce(mockResponse1)
-        .mockResolvedValueOnce(mockResponse2);
+        .mockResolvedValueOnce({
+          count: 1, next: null, previous: null, results: [pendingMemoNotRequester as PurchaseRequestMemo]
+        } as PaginatedResponse<PurchaseRequestMemo>)
+        .mockResolvedValueOnce({
+          count: 1, next: null, previous: null, results: [{...pendingMemoNotRequester, status: 'approved'} as PurchaseRequestMemo]
+        } as PaginatedResponse<PurchaseRequestMemo>);
       const decideMemoMock = vi.mocked(procurementApi.decidePurchaseRequestMemo).mockResolvedValue(undefined);
 
       const user = userEvent.setup();
@@ -693,15 +687,13 @@ describe('PurchaseRequestMemoList', () => {
             user: mockUserStaff,
         });
 
-        const mockResponse1: PaginatedResponse<PurchaseRequestMemo> = {
-          count: 1, next: null, previous: null, results: [pendingMemoIsRequester]
-        };
-        const mockResponse2: PaginatedResponse<PurchaseRequestMemo> = {
-          count: 1, next: null, previous: null, results: [{...pendingMemoIsRequester, status: 'rejected'}]
-        };
         const getMemosMock = vi.mocked(procurementApi.getPurchaseRequestMemos)
-            .mockResolvedValueOnce(mockResponse1)
-            .mockResolvedValueOnce(mockResponse2);
+            .mockResolvedValueOnce({
+              count: 1, next: null, previous: null, results: [pendingMemoIsRequester as PurchaseRequestMemo]
+            } as PaginatedResponse<PurchaseRequestMemo>)
+            .mockResolvedValueOnce({
+              count: 1, next: null, previous: null, results: [{...pendingMemoIsRequester, status: 'rejected'} as PurchaseRequestMemo]
+            } as PaginatedResponse<PurchaseRequestMemo>);
         const decideMemoMock = vi.mocked(procurementApi.decidePurchaseRequestMemo).mockResolvedValue(undefined);
 
         const user = userEvent.setup();


### PR DESCRIPTION
This commit addresses a series of TypeScript errors (TS2322, TS2345), resulting test failures, a runtime error concerning MUI's `useTheme` hook, and type issues in the generic IOM module. All tests for the affected modules are now passing.

Key changes include:

1.  **MUI `useTheme` Import Standardization:**
    *   Corrected `useTheme` imports in `LoginPage.tsx`, `HomePage.tsx`, and various PrintView components to consistently use `import { useTheme } from '@mui/material/styles';`. This resolved a runtime error related to Vite's pre-bundling.

2.  **Procurement Component Test Fixes (`CheckRequestDetailView.test.tsx`, `CheckRequestList.test.tsx`, `PurchaseRequestMemoList.test.tsx`, `AuthContext.test.tsx`):
    *   Corrected type inconsistencies for `AuthUser` in `AuthContext.test.tsx`.
    *   Addressed errors related to `null` or `undefined` arguments being passed to functions expecting concrete types. This involved ensuring API mocks provide valid data structures and that components handle potentially undefined selections gracefully.
    *   Refined date formatting assertions in `CheckRequestDetailView.test.tsx`.
    *   Updated assertions for "N/A" values and titles in `CheckRequestDetailView.test.tsx`.
    *   Ensured `PurchaseRequestMemoList.test.tsx` and `CheckRequestList.test.tsx` provide explicitly typed `PaginatedResponse` objects for mock API calls, with explicit `as CheckRequest` or `as PurchaseRequestMemo` casting for objects within the `results` arrays to satisfy TypeScript static analysis for TS2345 errors.

3.  **Date Formatter Fix (`src/utils/formatters.ts` and `formatters.test.ts`):
    *   Modified the `formatDate` utility to prevent timezone-related shifts for 'YYYY-MM-DD' output.
    *   Changed `const date` to `let date` within `formatDate`.
    *   Adjusted assertions in `formatters.test.ts` to align with the corrected behavior of `formatDate`.

4.  **Generic IOM Component Type Fixes (`GenericIomDetailComponent.tsx`, `GenericIomForm.tsx`, `IomPreviewRenderer.tsx`):
    *   Addressed TS2322 errors (`Type 'unknown' is not assignable to type 'FormFieldValue'`) by applying type assertions (`as FormFieldValue`) when passing values from `IomDataPayload` to components expecting `FormFieldValue`.

All targeted tests for the procurement module components, generic IOM components, `formatters.ts`, `LoginPage.tsx`, and `HomePage.tsx` are now passing. Pre-existing unrelated test failures in other modules remain.