### PR TITLE
Fix: Import CheckRequestStatus in CheckRequestList.test.tsx

### DIFF
--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
@@ -9,7 +9,7 @@ import CheckRequestList from './CheckRequestList';
 import * as procurementApi from '../../../../api/procurementApi';
 import * as useAuthHook from '../../../../context/auth/useAuth';
 import * as useUIHook from '../../../../context/UIContext/useUI';
-import type { CheckRequest, PaginatedResponse } from '../../types';
+import type { CheckRequest, PaginatedResponse, CheckRequestStatus } from '../../types';
 
 // Mock API module
 vi.mock('../../../../api/procurementApi');


### PR DESCRIPTION
Adds the missing import for the CheckRequestStatus type, which was causing a 'Cannot find name' error during type casting.