### PR TITLE
Chore: Clean up test files and acknowledge persistent TS errors

### DIFF
--- a/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/check-requests/CheckRequestList.test.tsx
@@ -9,8 +9,7 @@ import CheckRequestList from './CheckRequestList';
 import * as procurementApi from '../../../../api/procurementApi';
 import * as useAuthHook from '../../../../context/auth/useAuth';
 import * as useUIHook from '../../../../context/UIContext/useUI';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { CheckRequest, PaginatedResponse, CheckRequestStatus, ConfirmPaymentPayload } from '../../types'; // Removed PaymentMethod
+import type { CheckRequest, PaginatedResponse, CheckRequestStatus, ConfirmPaymentPayload } from '../../types'; // PaymentMethod was removed, so eslint-disable is no longer needed here.
 
 // Mock API module
 vi.mock('../../../../api/procurementApi');
@@ -40,22 +39,20 @@ const renderWithProviders = (ui: React.ReactElement) => {
 };
 
 // Helper to create a fully formed CheckRequest object with all optional fields
-const базовыйПолностьюЗаполненныйОбъектЗапросаНаЧек = (данныеОВнесенииИзмененийВЗапросНаЧек: Partial<CheckRequest>): CheckRequest => {
-  // Renamed to avoid any potential naming conflicts or weirdness with "defaults" if that's a keyword somewhere unexpected.
-  // Using a non-English name for the variable to be absolutely sure it doesn't clash.
-  const стандартныеЗначения: CheckRequest = {
+const createCompleteCheckRequest = (crData: Partial<CheckRequest>): CheckRequest => {
+  const defaults: CheckRequest = { // Reverted to "defaults" and English names
     id: 0,
     purchase_order: null,
     purchase_order_number: null,
     invoice_number: null,
     invoice_date: null,
     amount: "0.00",
-    payee_name: "Стандартный Получатель",
+    payee_name: "Default Payee",
     payee_address: null,
-    reason_for_payment: "Стандартная Причина",
+    reason_for_payment: "Default Reason",
     requested_by: 0,
-    requested_by_username: "стандартныйПользователь",
-    request_date: "2024-01-01T00:00:00.000Z", // Fixed date string
+    requested_by_username: "defaultuser",
+    request_date: "2024-01-01T00:00:00.000Z", // Keep fixed date string for determinism
     status: 'pending_submission',
     approved_by_accounts: null,
     approved_by_accounts_username: null,
@@ -73,14 +70,12 @@ const базовыйПолностьюЗаполненныйОбъектЗапр
     recurring_payment_details: null,
     attachments: null,
     currency: 'USD',
-    created_at: "2024-01-01T00:00:00.000Z", // Fixed date string
-    updated_at: "2024-01-01T00:00:00.000Z", // Fixed date string
+    created_at: "2024-01-01T00:00:00.000Z", // Keep fixed date string
+    updated_at: "2024-01-01T00:00:00.000Z", // Keep fixed date string
   };
-  return { ...стандартныеЗначения, ...данныеОВнесенииИзмененийВЗапросНаЧек };
+  return { ...defaults, ...crData };
 };
 
-// Re-aliasing for clarity in tests
-const createCompleteCheckRequest = базовыйПолностьюЗаполненныйОбъектЗапросаНаЧек;
 
 const mockCR0_base = createCompleteCheckRequest({
   id: 1, cr_id: 'CR-001', purchase_order: 1, purchase_order_number: 'PO-001',

--- a/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
+++ b/itsm_frontend/src/modules/procurement/components/purchase-request-memos/PurchaseRequestMemoList.test.tsx
@@ -10,7 +10,7 @@ import * as procurementApi from '../../../../api/procurementApi';
 import * as genericIomApi from '../../../../api/genericIomApi';
 import * as useAuthHook from '../../../../context/auth/useAuth';
 import * as useUIHook from '../../../../context/UIContext/useUI';
-import type { PurchaseRequestMemo, PaginatedResponse, PurchaseRequestStatus } from '../../types/procurementTypes';
+import type { PurchaseRequestMemo, PaginatedResponse } from '../../types/procurementTypes'; // Removed PurchaseRequestStatus
 import type { IOMTemplate } from '../../../iomTemplateAdmin/types/iomTemplateAdminTypes';
 
 
@@ -61,16 +61,16 @@ const renderWithProviders = (ui: React.ReactElement) => {
   );
 };
 
-const помошникСозданияЗавершенногоМеморандумаОЗакупке = (данныеМеморандума: Partial<PurchaseRequestMemo>): PurchaseRequestMemo => {
-  const стандартныеЗначенияМемо: PurchaseRequestMemo = {
+const createCompletePurchaseRequestMemo = (memoData: Partial<PurchaseRequestMemo>): PurchaseRequestMemo => {
+  const defaults: PurchaseRequestMemo = { // Reverted to "defaults" and English names
     id: 0,
-    item_description: "Стандартный Элемент",
+    item_description: "Default Item",
     quantity: 1,
-    reason: "Стандартная Причина",
+    reason: "Default Reason",
     estimated_cost: null,
     requested_by: 0,
-    requested_by_username: "стандартныйПользовательМемо",
-    request_date: "2024-01-01T00:00:00.000Z", // Fixed date
+    requested_by_username: "defaultUserMemo", // Adjusted for uniqueness from CR helper
+    request_date: "2024-01-01T00:00:00.000Z", // Keep fixed date
     status: 'pending',
     approver: null,
     approver_username: null,
@@ -86,14 +86,11 @@ const помошникСозданияЗавершенногоМеморанду
     suggested_vendor: null,
     suggested_vendor_name: null,
     attachments: null,
-    created_at: "2024-01-01T00:00:00.000Z", // Fixed date
-    updated_at: "2024-01-01T00:00:00.000Z", // Fixed date
+    created_at: "2024-01-01T00:00:00.000Z", // Keep fixed date
+    updated_at: "2024-01-01T00:00:00.000Z", // Keep fixed date
   };
-  return { ...стандартныеЗначенияМемо, ...данныеМеморандума };
+  return { ...defaults, ...memoData };
 };
-
-// Re-aliasing for clarity in tests
-const createCompletePurchaseRequestMemo = помошникСозданияЗавершенногоМеморандумаОЗакупке;
 
 
 const mockMemo0_base = createCompletePurchaseRequestMemo({


### PR DESCRIPTION
This commit includes several cleanup actions for the test files:

1.  In `CheckRequestList.test.tsx`:
    *   Removed a now-unused `eslint-disable-next-line` comment related to a previous `PaymentMethod` import.
    *   Reverted a temporarily renamed helper function back to `createCompleteCheckRequest` for readability, using English names for internal variables and default strings.

2.  In `PurchaseRequestMemoList.test.tsx`:
    *   Removed the explicit import of `PurchaseRequestStatus` as it was flagged as unused and `PurchaseRequestMemo` should resolve its constituent types implicitly.
    *   Reverted a temporarily renamed helper function back to `createCompletePurchaseRequestMemo` for readability, using English names for internal variables and default strings.

Important Note:
The persistent "Argument of type 'undefined' is not assignable to parameter of type 'CheckRequest' (or 'PurchaseRequestMemo')" errors in these test files remain unresolved despite multiple extensive attempts to refine mock data structures (including fully explicit manual object literals).

The root cause of these errors is likely more complex than simple mock object incompleteness and may involve subtle interactions within the test environment (Vitest/JSDOM/RTL), component lifecycle, asynchronous operations, or state updates that are difficult to diagnose and fix without interactive debugging tools.

Further investigation of these persistent errors will likely require local debugging by the user to step through test execution and component state transitions.